### PR TITLE
Switch to Deepgram speech APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@11labs/react": "^0.1.2",
+    "@deepgram/sdk": "^4.5.1",
     "@auth0/auth0-react": "^2.3.0",
     "@auth0/auth0-spa-js": "^2.1.3",
     "@capacitor/camera": "^7.0.1",

--- a/src/components/VernonChat/hooks/speechSynthesis/useElevenLabsKeyManager.ts
+++ b/src/components/VernonChat/hooks/speechSynthesis/useElevenLabsKeyManager.ts
@@ -1,13 +1,13 @@
 
 import { useCallback } from 'react';
-import { ElevenLabsService } from '@/services/ElevenLabsService';
+import { DeepgramService } from '@/services';
 import { toast } from 'sonner';
 
 export const useElevenLabsKeyManager = (setUseElevenLabs: (value: boolean) => void) => {
   const promptForElevenLabsKey = useCallback((): void => {
     const apiKey = prompt('Enter your Eleven Labs API key for improved voice quality:');
     if (apiKey) {
-      ElevenLabsService.setApiKey(apiKey);
+      DeepgramService.setApiKey(apiKey);
       setUseElevenLabs(true);
       toast.success('Eleven Labs API key saved. Voice quality will be improved.');
     }

--- a/src/components/VernonChat/hooks/speechSynthesis/useElevenLabsSpeech.ts
+++ b/src/components/VernonChat/hooks/speechSynthesis/useElevenLabsSpeech.ts
@@ -1,6 +1,6 @@
 
 import { useCallback } from 'react';
-import { ElevenLabsService } from '@/services/ElevenLabsService';
+import { DeepgramService } from '@/services';
 import { toast } from '@/hooks/use-toast';
 
 interface UseElevenLabsSpeechProps {
@@ -35,8 +35,8 @@ export const useElevenLabsSpeech = ({
       currentlyPlayingText.current = text;
       
       // Request to convert text to speech
-      console.log('Requesting Eleven Labs text-to-speech with Adam voice');
-      const audioData = await ElevenLabsService.textToSpeech(text);
+      console.log('Requesting Deepgram text-to-speech');
+      const audioData = await DeepgramService.textToSpeech(text);
       
       if (!audioData || !audioElement.current) {
         console.error('Failed to get audio from Eleven Labs or audio element not available');

--- a/src/components/VernonChat/hooks/speechSynthesis/useElevenLabsVoice.ts
+++ b/src/components/VernonChat/hooks/speechSynthesis/useElevenLabsVoice.ts
@@ -1,15 +1,15 @@
 
 import { useState, useCallback } from 'react';
-import { ElevenLabsService } from '@/services/ElevenLabsService';
+import { DeepgramService } from '@/services';
 
 export const useElevenLabsVoice = () => {
-  const [isElevenLabsReady, setIsElevenLabsReady] = useState<boolean>(ElevenLabsService.hasApiKey());
+  const [isElevenLabsReady, setIsElevenLabsReady] = useState<boolean>(DeepgramService.hasApiKey());
   
   // Function to prompt user for ElevenLabs API key
   const promptForElevenLabsKey = useCallback(() => {
     const apiKey = prompt('Enter your Eleven Labs API key for improved voice quality:');
     if (apiKey) {
-      ElevenLabsService.setApiKey(apiKey);
+      DeepgramService.setApiKey(apiKey);
       setIsElevenLabsReady(true);
     }
   }, []);
@@ -17,7 +17,7 @@ export const useElevenLabsVoice = () => {
   // Function to speak using ElevenLabs
   const speakWithElevenLabs = useCallback(async (text: string): Promise<void> => {
     try {
-      const audioData = await ElevenLabsService.textToSpeech(text);
+      const audioData = await DeepgramService.textToSpeech(text);
       
       if (!audioData) {
         throw new Error('Failed to get audio from Eleven Labs');

--- a/src/components/VernonChat/hooks/speechSynthesis/useOptimizedSpeechSynthesis.ts
+++ b/src/components/VernonChat/hooks/speechSynthesis/useOptimizedSpeechSynthesis.ts
@@ -1,6 +1,6 @@
 
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { ElevenLabsService } from '@/services/ElevenLabsService';
+import { DeepgramService } from '@/services';
 import { configureSpeechSynthesis, createUtterance, handleSynthesisError } from './speechSynthesisUtils';
 import { toast } from 'sonner';
 
@@ -8,7 +8,7 @@ export const useOptimizedSpeechSynthesis = () => {
   // Core state
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
-  const [isElevenLabsReady, setIsElevenLabsReady] = useState<boolean>(ElevenLabsService.hasApiKey());
+  const [isElevenLabsReady, setIsElevenLabsReady] = useState<boolean>(DeepgramService.hasApiKey());
   
   // Refs for tracking
   const currentAudioRef = useRef<HTMLAudioElement | null>(null);
@@ -43,9 +43,9 @@ export const useOptimizedSpeechSynthesis = () => {
   // ElevenLabs speech function
   const speakWithElevenLabs = useCallback(async (text: string): Promise<boolean> => {
     try {
-      console.log('Using ElevenLabs TTS for:', text.substring(0, 50) + '...');
-      
-      const audioData = await ElevenLabsService.textToSpeech(text);
+      console.log('Using Deepgram TTS for:', text.substring(0, 50) + '...');
+
+      const audioData = await DeepgramService.textToSpeech(text);
       
       if (!audioData) {
         console.warn('No audio data from ElevenLabs');
@@ -87,7 +87,7 @@ export const useOptimizedSpeechSynthesis = () => {
         });
       });
     } catch (error) {
-      console.error('ElevenLabs speech error:', error);
+      console.error('Deepgram speech error:', error);
       setIsSpeaking(false);
       currentlyPlayingText.current = null;
       currentAudioRef.current = null;
@@ -156,7 +156,7 @@ export const useOptimizedSpeechSynthesis = () => {
       const success = await speakWithElevenLabs(text);
       if (success) return;
       
-      console.log('ElevenLabs failed, falling back to browser speech');
+      console.log('Deepgram failed, falling back to browser speech');
     }
     
     // Fallback to browser speech synthesis
@@ -181,9 +181,9 @@ export const useOptimizedSpeechSynthesis = () => {
   
   // ElevenLabs key management
   const promptForElevenLabsKey = useCallback(() => {
-    const apiKey = prompt('Enter your ElevenLabs API key for improved voice quality:');
+    const apiKey = prompt('Enter your Deepgram API key for improved voice quality:');
     if (apiKey) {
-      ElevenLabsService.setApiKey(apiKey);
+      DeepgramService.setApiKey(apiKey);
       setIsElevenLabsReady(true);
       toast.success('ElevenLabs API key set successfully!');
     }

--- a/src/components/VernonChat/utils/bookingAgent.ts
+++ b/src/components/VernonChat/utils/bookingAgent.ts
@@ -1,5 +1,5 @@
 
-import { ElevenLabsService } from '@/services/ElevenLabsService';
+import { DeepgramService } from '@/services';
 import { toast } from 'sonner';
 
 interface BookingDetails {
@@ -75,12 +75,12 @@ export const BookingAgent = {
     try {
       console.log('Attempting to book venue with details:', details);
       
-      // If ElevenLabs API key is available, try to use agent capabilities
-      if (ElevenLabsService.hasApiKey()) {
+      // If Deepgram API key is available, try to use agent capabilities
+      if (DeepgramService.hasApiKey()) {
         try {
-          // This would use the actual ElevenLabs agent API when available
+          // This would use the actual Deepgram agent API when available
           // Fix here: The createAgentTask expects an AgentTaskRequest object, not two separate arguments
-          const agentResponse = await ElevenLabsService.createAgentTask({
+          const agentResponse = await DeepgramService.createAgentTask({
             task: 'book_venue',
             user_id: 'user_' + Date.now(),
             conversation_id: 'conv_' + Date.now()
@@ -94,7 +94,7 @@ export const BookingAgent = {
             };
           }
         } catch (error) {
-          console.error('Error using ElevenLabs agent:', error);
+          console.error('Error using Deepgram agent:', error);
           // Fall back to simulation
         }
       }

--- a/src/services/Deepgram/base.ts
+++ b/src/services/Deepgram/base.ts
@@ -1,0 +1,34 @@
+export interface DeepgramOptions {
+  model?: string;
+  voice?: string;
+  language?: string;
+}
+
+export class DeepgramBase {
+  private static apiKey: string | null = null;
+
+  public static setApiKey(apiKey: string) {
+    this.apiKey = apiKey;
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('deepgramApiKey', apiKey);
+    }
+  }
+
+  public static getApiKey(): string | null {
+    if (!this.apiKey && typeof localStorage !== 'undefined') {
+      this.apiKey = localStorage.getItem('deepgramApiKey');
+    }
+    return this.apiKey;
+  }
+
+  public static clearApiKey() {
+    this.apiKey = null;
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem('deepgramApiKey');
+    }
+  }
+
+  public static hasApiKey(): boolean {
+    return !!this.getApiKey();
+  }
+}

--- a/src/services/Deepgram/index.ts
+++ b/src/services/Deepgram/index.ts
@@ -1,0 +1,22 @@
+import { DeepgramBase } from './base';
+import { DeepgramTextToSpeech } from './textToSpeech';
+import { DeepgramSpeechToText } from './speechToText';
+
+export class DeepgramService {
+  public static setApiKey = DeepgramBase.setApiKey;
+  public static getApiKey = DeepgramBase.getApiKey;
+  public static clearApiKey = DeepgramBase.clearApiKey;
+  public static hasApiKey = DeepgramBase.hasApiKey;
+
+  public static textToSpeech = DeepgramTextToSpeech.textToSpeech;
+  public static speechToText = DeepgramSpeechToText.speechToText;
+
+  // Compatibility stubs
+  public static getVoices = async () => null;
+  public static getVoice = async (_voiceId: string) => null;
+  public static createAgentTask = async (_req: any) => null;
+  public static getSignedUrl = async (_agentId: string) => null;
+  public static getAgentInfo = async (_agentId: string) => null;
+}
+
+export type { DeepgramOptions } from './base';

--- a/src/services/Deepgram/speechToText.ts
+++ b/src/services/Deepgram/speechToText.ts
@@ -1,0 +1,39 @@
+import { DeepgramBase, DeepgramOptions } from './base';
+
+export class DeepgramSpeechToText {
+  public static async speechToText(audioData: ArrayBuffer | Blob, options: DeepgramOptions = {}): Promise<string | null> {
+    const apiKey = DeepgramBase.getApiKey();
+    if (!apiKey) {
+      console.error('Deepgram API key not set');
+      return null;
+    }
+
+    try {
+      const model = options.model || 'nova-3';
+      const language = options.language || 'en-US';
+      const url = `https://api.deepgram.com/v1/listen?model=${model}&language=${language}`;
+
+      const body = audioData instanceof Blob ? audioData : new Blob([audioData]);
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Token ${apiKey}`,
+          'Content-Type': body.type || 'audio/wav'
+        },
+        body
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Deepgram STT API error: ${errorText}`);
+      }
+
+      const data = await response.json();
+      return data.results?.channels?.[0]?.alternatives?.[0]?.transcript || null;
+    } catch (error) {
+      console.error('Error in Deepgram speech-to-text:', error);
+      return null;
+    }
+  }
+}

--- a/src/services/Deepgram/textToSpeech.ts
+++ b/src/services/Deepgram/textToSpeech.ts
@@ -1,0 +1,35 @@
+import { DeepgramBase, DeepgramOptions } from './base';
+
+export class DeepgramTextToSpeech {
+  public static async textToSpeech(text: string, options: DeepgramOptions = {}): Promise<ArrayBuffer | null> {
+    const apiKey = DeepgramBase.getApiKey();
+    if (!apiKey) {
+      console.error('Deepgram API key not set');
+      return null;
+    }
+
+    try {
+      const model = options.model || 'aura-asteria-en';
+      const url = `https://api.deepgram.com/v1/speak?model=${model}`;
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Token ${apiKey}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ text })
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Deepgram TTS API error: ${errorText}`);
+      }
+
+      return await response.arrayBuffer();
+    } catch (error) {
+      console.error('Error in Deepgram text-to-speech:', error);
+      return null;
+    }
+  }
+}

--- a/src/services/ElevenLabsService.ts
+++ b/src/services/ElevenLabsService.ts
@@ -1,5 +1,0 @@
-
-// Re-export everything from the refactored ElevenLabs service
-export { ElevenLabsService } from './ElevenLabs';
-// Use 'export type' for type re-exports
-export type { ElevenLabsOptions, ScribeTranscriptionOptions } from './ElevenLabs';

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,11 +1,11 @@
 
 // Centralized service exports
-export { ElevenLabsService } from './ElevenLabs';
+export { DeepgramService } from './Deepgram';
 export { VertexAIService } from './VertexAIService';
 export { OpenAIService } from './OpenAIService';
 export { GeminiService } from './GeminiService';
 export { SocialMediaAggregator } from './socialMedia/aggregator';
 
 // Service types
-export type { ElevenLabsOptions, ScribeTranscriptionOptions } from './ElevenLabs';
+export type { DeepgramOptions } from './Deepgram';
 export type { SocialMediaApiKeys, SocialMediaPost } from './socialMedia/types';

--- a/supabase/functions/generate-audio/index.ts
+++ b/supabase/functions/generate-audio/index.ts
@@ -19,44 +19,26 @@ serve(async (req) => {
       throw new Error('Text is required')
     }
 
-    const elevenLabsApiKey = Deno.env.get('ELEVEN_LABS_API_KEY')
-    if (!elevenLabsApiKey) {
-      throw new Error('ElevenLabs API key not configured')
+    const deepgramApiKey = Deno.env.get('DEEPGRAM_API_KEY')
+    if (!deepgramApiKey) {
+      throw new Error('Deepgram API key not configured')
     }
 
-    // Voice ID mapping
-    const voiceIds: Record<string, string> = {
-      'Sarah': 'EXAVITQu4vr4xnSDxMaL',
-      'Charlie': 'IKne3meq5aSn9XLyUdCD',
-      'George': 'JBFqnCBsd6RMkjVDRZzb',
-      'default': 'EXAVITQu4vr4xnSDxMaL'
-    }
+    const model = 'aura-asteria-en'
 
-    const voiceId = voiceIds[voice] || voiceIds.default
-
-    // Generate speech using ElevenLabs
-    const response = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`, {
+    const response = await fetch(`https://api.deepgram.com/v1/speak?model=${model}`, {
       method: 'POST',
       headers: {
         'Accept': 'audio/mpeg',
         'Content-Type': 'application/json',
-        'xi-api-key': elevenLabsApiKey,
+        'Authorization': `Token ${deepgramApiKey}`,
       },
-      body: JSON.stringify({
-        text: text,
-        model_id: 'eleven_multilingual_v2',
-        voice_settings: {
-          stability: 0.5,
-          similarity_boost: 0.5,
-          style: 0.0,
-          use_speaker_boost: true
-        }
-      }),
+      body: JSON.stringify({ text })
     })
 
     if (!response.ok) {
       const error = await response.text()
-      console.error('ElevenLabs API error:', error)
+      console.error('Deepgram API error:', error)
       throw new Error(`Failed to generate speech: ${response.status}`)
     }
 


### PR DESCRIPTION
## Summary
- add Deepgram service with TTS and STT helpers
- update service exports and remove old ElevenLabs service
- change Supabase functions to use Deepgram
- replace ElevenLabs usage in hooks and utils
- install `@deepgram/sdk` and drop `@11labs/react`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856a9d21244832a85a74d19b061f2e8