### PR TITLE
Switch speech hooks to Deepgram

### DIFF
--- a/src/components/VernonChat/hooks/speechInteraction/index.tsx
+++ b/src/components/VernonChat/hooks/speechInteraction/index.tsx
@@ -26,8 +26,8 @@ export const useSpeechInteraction = () => {
     speakResponse,
     stopSpeaking,
     // These are now added to the return object in useSpeechSynthesis
-    useElevenLabs,
-    promptForElevenLabsKey
+    useDeepgram,
+    promptForDeepgramKey
   } = useSpeechSynthesis();
   
   // Set up voice initialization
@@ -96,8 +96,8 @@ export const useSpeechInteraction = () => {
     stopSpeaking,
     speakResponse,
     processTranscript,
-    useElevenLabs,
-    promptForElevenLabsKey,
+    useDeepgram,
+    promptForDeepgramKey,
     hasSpokenIntro,
     markIntroAsSpoken,
     isFirstInteraction,

--- a/src/components/VernonChat/hooks/speechSynthesis/index.ts
+++ b/src/components/VernonChat/hooks/speechSynthesis/index.ts
@@ -8,9 +8,9 @@ export { useSpeechSynthesisCore } from './useSpeechSynthesisCore';
 export { useSpeakResponse } from './useSpeakResponse';
 export { useElevenLabsKeyManager } from './useElevenLabsKeyManager';
 export { useSpeechSynthesisVoices } from './useSpeechSynthesisVoices';
-export { useElevenLabsVoice } from './useElevenLabsVoice';
+export { useDeepgramVoice } from './useDeepgramVoice';
 export { useBrowserSpeechSynthesis } from './useBrowserSpeechSynthesis';
-export { useElevenLabsSpeech } from './useElevenLabsSpeech';
+export { useDeepgramSpeech } from './useDeepgramSpeech';
 
 // Export utility functions
 export { 

--- a/src/components/VernonChat/hooks/speechSynthesis/useDeepgramSpeech.ts
+++ b/src/components/VernonChat/hooks/speechSynthesis/useDeepgramSpeech.ts
@@ -1,0 +1,96 @@
+
+import { useCallback } from 'react';
+import { DeepgramService } from '@/services';
+import { toast } from '@/hooks/use-toast';
+
+interface UseDeepgramSpeechProps {
+  audioElement: React.MutableRefObject<HTMLAudioElement | null>;
+  isSpeaking: boolean;
+  setIsSpeaking: (value: boolean) => void;
+  currentlyPlayingText: React.MutableRefObject<string | null>;
+  stopSpeaking: () => void;
+}
+
+export const useDeepgramSpeech = ({
+  audioElement,
+  isSpeaking,
+  setIsSpeaking,
+  currentlyPlayingText,
+  stopSpeaking
+}: UseDeepgramSpeechProps) => {
+  
+  const speakWithDeepgram = useCallback(async (text: string): Promise<boolean> => {
+    try {
+      // Don't repeat the same text if it's already playing
+      if (isSpeaking && currentlyPlayingText.current === text) {
+        console.log('This text is already being spoken, skipping duplicate');
+        return true;
+      }
+      
+      // Stop any currently playing speech first
+      stopSpeaking();
+      
+      // Set state to speaking and track current text
+      setIsSpeaking(true);
+      currentlyPlayingText.current = text;
+      
+      // Request to convert text to speech
+      console.log('Requesting Deepgram text-to-speech');
+      const audioData = await DeepgramService.textToSpeech(text);
+      
+      if (!audioData || !audioElement.current) {
+        console.error('Failed to get audio from Deepgram or audio element not available');
+        // If failed, don't show error toast as the browser speech synthesis will take over
+        setIsSpeaking(false);
+        currentlyPlayingText.current = null;
+        return false;
+      }
+      
+      // Create blob from array buffer
+      const blob = new Blob([audioData], { type: 'audio/mpeg' });
+      const url = URL.createObjectURL(blob);
+      
+      // Set audio source and play
+      audioElement.current.src = url;
+      
+      try {
+        await audioElement.current.play();
+        
+        // Clean up blob URL after playback
+        audioElement.current.onended = () => {
+          URL.revokeObjectURL(url);
+          setIsSpeaking(false);
+          currentlyPlayingText.current = null;
+        };
+        return true;
+      } catch (error) {
+        console.error('Error playing audio:', error);
+        URL.revokeObjectURL(url);
+        setIsSpeaking(false);
+        currentlyPlayingText.current = null;
+        return false;
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('quota_exceeded')) {
+        console.warn('Deepgram quota exceeded, falling back to browser speech');
+        // Show toast only once per session
+        if (!localStorage.getItem('deepgram_quota_notified')) {
+          toast({
+            title: "Voice Synthesis Fallback",
+            description: "Your Deepgram quota has been exceeded. Using browser voice instead.",
+            duration: 5000,
+          });
+          localStorage.setItem('deepgram_quota_notified', 'true');
+        }
+      } else {
+        console.error('Error with Deepgram speech synthesis:', error);
+      }
+      
+      setIsSpeaking(false);
+      currentlyPlayingText.current = null;
+      return false;
+    }
+  }, [audioElement, isSpeaking, currentlyPlayingText, setIsSpeaking, stopSpeaking]);
+  
+  return { speakWithDeepgram };
+};

--- a/src/components/VernonChat/hooks/speechSynthesis/useDeepgramVoice.ts
+++ b/src/components/VernonChat/hooks/speechSynthesis/useDeepgramVoice.ts
@@ -2,25 +2,25 @@
 import { useState, useCallback } from 'react';
 import { DeepgramService } from '@/services';
 
-export const useElevenLabsVoice = () => {
-  const [isElevenLabsReady, setIsElevenLabsReady] = useState<boolean>(DeepgramService.hasApiKey());
+export const useDeepgramVoice = () => {
+  const [isDeepgramReady, setIsDeepgramReady] = useState<boolean>(DeepgramService.hasApiKey());
   
   // Function to prompt user for Deepgram API key
-  const promptForElevenLabsKey = useCallback(() => {
+  const promptForDeepgramKey = useCallback(() => {
     const apiKey = prompt('Enter your Deepgram API key for improved voice quality:');
     if (apiKey) {
       DeepgramService.setApiKey(apiKey);
-      setIsElevenLabsReady(true);
+      setIsDeepgramReady(true);
     }
   }, []);
   
-  // Function to speak using ElevenLabs
-  const speakWithElevenLabs = useCallback(async (text: string): Promise<void> => {
+  // Function to speak using Deepgram
+  const speakWithDeepgram = useCallback(async (text: string): Promise<void> => {
     try {
       const audioData = await DeepgramService.textToSpeech(text);
       
       if (!audioData) {
-        throw new Error('Failed to get audio from Eleven Labs');
+        throw new Error('Failed to get audio from Deepgram');
       }
       
       // Create a blob from the audio data
@@ -44,13 +44,13 @@ export const useElevenLabsVoice = () => {
         audio.play().catch(reject);
       });
     } catch (error) {
-      console.error('Error with Eleven Labs speech:', error);
+      console.error('Error with Deepgram speech:', error);
       throw error;
     }
   }, []);
   
-  // Function to cancel ElevenLabs speech
-  const cancelElevenLabsSpeech = useCallback(() => {
+  // Function to cancel Deepgram speech
+  const cancelDeepgramSpeech = useCallback(() => {
     // This is a simple implementation
     // In a more complex app, you might need to track active audio elements
     const audios = document.querySelectorAll('audio');
@@ -61,9 +61,9 @@ export const useElevenLabsVoice = () => {
   }, []);
   
   return {
-    isElevenLabsReady,
-    speakWithElevenLabs,
-    promptForElevenLabsKey,
-    cancelElevenLabsSpeech
+    isDeepgramReady,
+    speakWithDeepgram,
+    promptForDeepgramKey,
+    cancelDeepgramSpeech
   };
 };

--- a/src/components/VernonChat/hooks/speechSynthesis/useElevenLabsKeyManager.ts
+++ b/src/components/VernonChat/hooks/speechSynthesis/useElevenLabsKeyManager.ts
@@ -5,12 +5,12 @@ import { toast } from 'sonner';
 
 export const useElevenLabsKeyManager = (setUseElevenLabs: (value: boolean) => void) => {
   const promptForElevenLabsKey = useCallback((): void => {
-    const apiKey = prompt('Enter your Eleven Labs API key for improved voice quality:');
+    const apiKey = prompt('Enter your Deepgram API key for improved voice quality:');
     if (apiKey) {
       DeepgramService.setApiKey(apiKey);
       setUseElevenLabs(true);
-      toast.success('Eleven Labs API key saved. Voice quality will be improved.');
-    }
+      toast.success('Deepgram API key saved. Voice quality will be improved.');
+  }
   }, [setUseElevenLabs]);
 
   return { promptForElevenLabsKey };

--- a/src/components/VernonChat/hooks/useDeepgramVoice.ts
+++ b/src/components/VernonChat/hooks/useDeepgramVoice.ts
@@ -1,0 +1,49 @@
+import { useState, useCallback } from 'react';
+import { DeepgramService } from '@/services';
+
+export const useDeepgramVoice = () => {
+  const [isDeepgramReady, setIsDeepgramReady] = useState<boolean>(DeepgramService.hasApiKey());
+
+  const speakWithDeepgram = useCallback(async (text: string): Promise<boolean> => {
+    try {
+      console.log('Using Deepgram TTS for:', text.substring(0, 50) + '...');
+      const audioData = await DeepgramService.textToSpeech(text);
+
+      if (!audioData) {
+        console.error('No audio data received from Deepgram');
+        return false;
+      }
+
+      const audio = new Audio();
+      const blob = new Blob([audioData], { type: 'audio/mpeg' });
+      const url = URL.createObjectURL(blob);
+      audio.src = url;
+
+      return new Promise((resolve) => {
+        audio.onended = () => {
+          URL.revokeObjectURL(url);
+          resolve(true);
+        };
+
+        audio.onerror = () => {
+          URL.revokeObjectURL(url);
+          console.error('Audio playback error');
+          resolve(false);
+        };
+
+        audio.play().catch(() => {
+          URL.revokeObjectURL(url);
+          resolve(false);
+        });
+      });
+    } catch (error) {
+      console.error('Error with Deepgram speech:', error);
+      return false;
+    }
+  }, []);
+
+  return {
+    isDeepgramReady,
+    speakWithDeepgram
+  };
+};

--- a/src/components/VernonChat/hooks/useEnhancedSpeechSynthesis.ts
+++ b/src/components/VernonChat/hooks/useEnhancedSpeechSynthesis.ts
@@ -1,11 +1,11 @@
 
 import { useState, useCallback, useRef } from 'react';
-import { useElevenLabsVoice } from './useElevenLabsVoice';
+import { useDeepgramVoice } from './useDeepgramVoice';
 
 export const useEnhancedSpeechSynthesis = () => {
   const [isSpeaking, setIsSpeaking] = useState(false);
   const currentAudioRef = useRef<HTMLAudioElement | null>(null);
-  const { speakWithElevenLabs } = useElevenLabsVoice();
+  const { speakWithDeepgram } = useDeepgramVoice();
   
   const speak = useCallback(async (text: string): Promise<void> => {
     if (!text.trim()) return;
@@ -18,7 +18,7 @@ export const useEnhancedSpeechSynthesis = () => {
     setIsSpeaking(true);
     
     try {
-      const success = await speakWithElevenLabs(text);
+      const success = await speakWithDeepgram(text);
       
       if (!success) {
         console.log('Falling back to browser speech synthesis');
@@ -30,7 +30,7 @@ export const useEnhancedSpeechSynthesis = () => {
     } finally {
       setIsSpeaking(false);
     }
-  }, [speakWithElevenLabs]);
+  }, [speakWithDeepgram]);
   
   const fallbackToSpeechSynthesis = useCallback(async (text: string): Promise<void> => {
     return new Promise((resolve) => {

--- a/src/components/VernonChat/hooks/useSpeechSynthesis.tsx
+++ b/src/components/VernonChat/hooks/useSpeechSynthesis.tsx
@@ -119,8 +119,8 @@ export const useSpeechSynthesis = () => {
     speakResponse,
     stopSpeaking,
     togglePause,
-    useElevenLabs: false,
-    promptForElevenLabsKey: () => {
+    useDeepgram: false,
+    promptForDeepgramKey: () => {
       toast.info("Using browser's built-in speech services");
     }
   };


### PR DESCRIPTION
## Summary
- add `useDeepgramVoice` and `useDeepgramSpeech` hooks
- wire up Deepgram hooks in `useOptimizedSpeechSynthesis`
- update enhanced speech hooks and interaction hook to use Deepgram
- replace ElevenLabs key prompts with Deepgram prompts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856aca02578832aba83f4e61458fd9a