### PR TITLE
Add chat settings controls for voice output

### DIFF
--- a/src/components/VernonChat/ChatWindow.tsx
+++ b/src/components/VernonChat/ChatWindow.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef } from 'react';
 import { X, Send, Mic, MicOff, User, Bot, Trash2, Volume2 } from 'lucide-react';
 import { ChatWindowProps, Message } from './types';
+import ChatSettings from './components/ChatSettings';
 
 const ChatWindow: React.FC<ChatWindowProps> = ({
   messages,
@@ -16,7 +17,13 @@ const ChatWindow: React.FC<ChatWindowProps> = ({
   isListening,
   toggleListening,
   isModelLoading,
-  transcript
+  transcript,
+  voiceModel,
+  setVoiceModel,
+  volume,
+  setVolume,
+  speed,
+  setSpeed
 }) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -121,6 +128,19 @@ const ChatWindow: React.FC<ChatWindowProps> = ({
           >
             {chatMode === 'user' ? 'User' : 'Venue'}
           </button>
+          <ChatSettings
+            isListening={isListening}
+            isVenueMode={chatMode === 'venue'}
+            isModelLoading={isModelLoading}
+            toggleListening={toggleListening}
+            toggleVenueMode={toggleMode}
+            voiceModel={voiceModel}
+            onVoiceChange={setVoiceModel}
+            volume={volume}
+            onVolumeChange={setVolume}
+            speed={speed}
+            onSpeedChange={setSpeed}
+          />
           <button
             onClick={clearMessages}
             className="p-1 rounded-md hover:bg-muted"

--- a/src/components/VernonChat/components/ChatSettings.tsx
+++ b/src/components/VernonChat/components/ChatSettings.tsx
@@ -12,6 +12,9 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Slider } from '@/components/ui/slider';
+import { Label } from '@/components/ui/label';
 
 interface ChatSettingsProps {
   isListening: boolean;
@@ -19,6 +22,12 @@ interface ChatSettingsProps {
   isModelLoading: boolean;
   toggleListening: () => void;
   toggleVenueMode: () => void;
+  voiceModel: string;
+  onVoiceChange: (v: string) => void;
+  volume: number;
+  onVolumeChange: (v: number) => void;
+  speed: number;
+  onSpeedChange: (v: number) => void;
 }
 
 const ChatSettings: React.FC<ChatSettingsProps> = ({
@@ -27,14 +36,34 @@ const ChatSettings: React.FC<ChatSettingsProps> = ({
   isModelLoading,
   toggleListening,
   toggleVenueMode,
+  voiceModel,
+  onVoiceChange,
+  volume,
+  onVolumeChange,
+  speed,
+  onSpeedChange,
 }) => {
+  const voiceOptions = [
+    'aura-angus-en',
+    'aura-arcas-en',
+    'aura-asteria-en',
+    'aura-athena-en',
+    'aura-helios-en',
+    'aura-hera-en',
+    'aura-luna-en',
+    'aura-orion-en',
+    'aura-orpheus-en',
+    'aura-perseus-en',
+    'aura-stella-en',
+    'aura-zeus-en'
+  ];
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button 
-          variant="ghost" 
-          size="icon" 
-          className="absolute top-3 right-12 h-8 w-8 text-gray-400 hover:text-white hover:bg-gray-700"
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 text-gray-400 hover:text-white hover:bg-gray-700"
         >
           <Settings className="h-4 w-4" />
         </Button>
@@ -78,6 +107,30 @@ const ChatSettings: React.FC<ChatSettingsProps> = ({
               onCheckedChange={toggleListening}
               className="bg-gray-600 data-[state=checked]:bg-red-500"
             />
+          </div>
+
+          <div className="mt-4 space-y-3">
+            <div>
+              <Label className="text-xs">Voice</Label>
+              <Select value={voiceModel} onValueChange={onVoiceChange}>
+                <SelectTrigger className="mt-1 h-8">
+                  <SelectValue placeholder="Select voice" />
+                </SelectTrigger>
+                <SelectContent>
+                  {voiceOptions.map(v => (
+                    <SelectItem key={v} value={v}>{v}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label className="text-xs">Volume</Label>
+              <Slider min={0} max={1} step={0.1} value={[volume]} onValueChange={(val) => onVolumeChange(val[0])} className="mt-1" />
+            </div>
+            <div>
+              <Label className="text-xs">Speed</Label>
+              <Slider min={0.5} max={2} step={0.1} value={[speed]} onValueChange={(val) => onSpeedChange(val[0])} className="mt-1" />
+            </div>
           </div>
           
           {isModelLoading && (

--- a/src/components/VernonChat/hooks/useEnhancedVernonChat.ts
+++ b/src/components/VernonChat/hooks/useEnhancedVernonChat.ts
@@ -13,6 +13,10 @@ export const useEnhancedVernonChat = () => {
   const [isProcessing, setIsProcessing] = useState(false);
   const [chatMode, setChatMode] = useLocalStorage<ChatMode>('vernon_chat_mode', 'user');
   const { processMessage } = useMessageProcessor();
+
+  const [voiceModel, setVoiceModel] = useLocalStorage<string>('vernon_voice_model', 'aura-asteria-en');
+  const [volume, setVolume] = useLocalStorage<number>('vernon_volume', 1);
+  const [speed, setSpeed] = useLocalStorage<number>('vernon_speed', 1);
   
   // Use optimized speech hooks
   const { speak, stop: stopSpeaking, isSpeaking } = useOptimizedSpeechSynthesis();
@@ -60,14 +64,14 @@ export const useEnhancedVernonChat = () => {
       
       // Auto-speak response if listening mode is active
       if (isListening) {
-        await speak(response);
+        await speak(response, { model: voiceModel, volume, rate: speed });
       }
     } catch (error) {
       console.error('Error processing message:', error);
       const errorMsg = 'Sorry, I encountered an error. Please try again later.';
       addMessage(errorMsg, 'incoming');
       if (isListening) {
-        await speak(errorMsg);
+        await speak(errorMsg, { model: voiceModel, volume, rate: speed });
       }
     } finally {
       setIsProcessing(false);
@@ -134,6 +138,12 @@ export const useEnhancedVernonChat = () => {
     clearMessages,
     isListening,
     toggleListening,
+    voiceModel,
+    setVoiceModel,
+    volume,
+    setVolume,
+    speed,
+    setSpeed,
     transcript: interimTranscript || transcript,
     isSpeaking,
     initializeWelcomeMessage,

--- a/src/components/VernonChat/index.tsx
+++ b/src/components/VernonChat/index.tsx
@@ -18,6 +18,12 @@ const VernonChat: React.FC = () => {
     clearMessages,
     isListening,
     toggleListening,
+    voiceModel,
+    setVoiceModel,
+    volume,
+    setVolume,
+    speed,
+    setSpeed,
     transcript,
     isSpeaking,
     initializeWelcomeMessage
@@ -45,6 +51,12 @@ const VernonChat: React.FC = () => {
           toggleListening={toggleListening}
           isModelLoading={false}
           transcript={transcript}
+          voiceModel={voiceModel}
+          setVoiceModel={setVoiceModel}
+          volume={volume}
+          setVolume={setVolume}
+          speed={speed}
+          setSpeed={setSpeed}
         />
       ) : (
         <ChatButton onClick={toggleChat} />

--- a/src/components/VernonChat/types.ts
+++ b/src/components/VernonChat/types.ts
@@ -29,6 +29,12 @@ export interface ChatWindowProps {
   toggleListening: () => void;
   isModelLoading: boolean;
   transcript: string;
+  voiceModel: string;
+  setVoiceModel: React.Dispatch<React.SetStateAction<string>>;
+  volume: number;
+  setVolume: React.Dispatch<React.SetStateAction<number>>;
+  speed: number;
+  setSpeed: React.Dispatch<React.SetStateAction<number>>;
   input?: string;
   setInput?: React.Dispatch<React.SetStateAction<string>>;
 }


### PR DESCRIPTION
## Summary
- import `ChatSettings` in `ChatWindow`
- add dropdown to configure assistant voice, volume and speed
- expose new speech options through `useEnhancedVernonChat`
- wire `ChatWindow` header to show settings button
- update speech synthesis hook to respect voice options

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856aee024a8832aab7a1b9c48c1b77b