### PR TITLE
Fix ExploreSearch city buttons

### DIFF
--- a/src/components/explore/ExploreSearchSection.tsx
+++ b/src/components/explore/ExploreSearchSection.tsx
@@ -105,10 +105,10 @@ const ExploreSearchSection: React.FC<ExploreSearchSectionProps> = ({
                       <Button
                         key={index}
                         variant="ghost"
-                        className="w-full justify-start text-left p-2 h-auto"
+                        className="w-full justify-start text-left p-2 h-12"
                         onClick={() => handleLocationSelect(city)}
                       >
-                        <div>
+                        <div className="truncate overflow-hidden">
                           <div className="font-medium">{city}</div>
                           <div className="text-sm text-muted-foreground">
                             United States


### PR DESCRIPTION
## Summary
- keep location list items at `h-12` height
- ensure long city names truncate rather than overflow

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: connect ENETUNREACH 140.82.112.3:443)*

------
https://chatgpt.com/codex/tasks/task_e_6856b48d67f8832a8808e5c7130ab5f0