### PR TITLE
Fix Deepgram API key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ This project is built with .
 
 Simply open [Lovable](https://lovable.dev/projects/6615c5b7-93f5-41b0-b375-6a37437bdc16) and click on Share -> Publish.
 
+## Supabase setup
+
+Make sure the `DEEPGRAM_API_KEY` environment variable is defined in your Supabase project so the Deepgram speech functions can operate correctly.
+
 ## I want to use a custom domain - is that possible?
 
 We don't support custom domains (yet). If you want to deploy your project under your own domain then we recommend using Netlify. Visit our docs for more details: [Custom domains](https://docs.lovable.dev/tips-tricks/custom-domain/)

--- a/supabase/functions/eleven-labs-tts/index.ts
+++ b/supabase/functions/eleven-labs-tts/index.ts
@@ -10,7 +10,7 @@ import { corsHeaders } from "../_shared/cors.ts";
 const DEFAULT_MODEL = "aura-asteria-en";
 
 const handler = withErrorHandling(async (req: Request): Promise<Response> => {
-  const DEEPGRAM_API_KEY = Deno.env.get('DEEPGRAM_API_KEY') || '';
+  const DEEPGRAM_API_KEY = Deno.env.get('DEEPGRAM_API_KEY');
 
   if (!DEEPGRAM_API_KEY) {
     return createValidationErrorResponse('Deepgram API key not configured');


### PR DESCRIPTION
## Summary
- ensure the Deepgram API key is retrieved without fallback in the eleven-labs-tts function
- document the `DEEPGRAM_API_KEY` requirement in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856b952d664832a96fcfe6fc79393f9