### PR TITLE
Update audio function docs and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,8 @@ Simply open [Lovable](https://lovable.dev/projects/6615c5b7-93f5-41b0-b375-6a374
 ## I want to use a custom domain - is that possible?
 
 We don't support custom domains (yet). If you want to deploy your project under your own domain then we recommend using Netlify. Visit our docs for more details: [Custom domains](https://docs.lovable.dev/tips-tricks/custom-domain/)
+
+## Audio generation
+
+The `generate-audio` Supabase Edge Function converts text to speech using the Deepgram API. To enable it, set the `DEEPGRAM_API_KEY` environment variable in your Supabase project.
+

--- a/supabase/functions/generate-audio/index.ts
+++ b/supabase/functions/generate-audio/index.ts
@@ -13,7 +13,7 @@ serve(async (req) => {
   }
 
   try {
-    const { text, voice } = await req.json()
+    const { text } = await req.json()
 
     if (!text) {
       throw new Error('Text is required')


### PR DESCRIPTION
## Summary
- use Deepgram API for `generate-audio`
- document audio generation via Deepgram in README
- remove unused `voice` parameter

## Testing
- `npm install` *(fails: connect ENETUNREACH)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856b9864b94832ab26a09b29bda5014