### PR TITLE
Switch to VernonNext chat

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Suspense, lazy, useEffect } from "react";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/ThemeProvider";
-import VernonChat from '@/components/VernonChat';
+import VernonNext from '@/components/VernonNext';
 import { Auth0Provider } from "./auth/Auth0Provider";
 
 // Lazy-loaded components
@@ -79,7 +79,7 @@ function App() {
               <Route path="*" element={<NotFound />} />
             </Routes>
           </Suspense>
-          <VernonChat />
+          <VernonNext />
           <Toaster />
         </BrowserRouter>
       </ThemeProvider>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import { Layout } from "@/components/Layout";
 import PostFeed from "@/components/PostFeed";
 import CameraButton from "@/components/CameraButton";
-import VernonNext from "@/components/VernonNext";
 import SearchVibes from "@/components/SearchVibes";
 import { useIsMobile } from "@/hooks/use-mobile";
 
@@ -56,7 +55,6 @@ const Index = () => {
       </main>
       
       <CameraButton />
-      <VernonNext />
     </Layout>
   );
 };


### PR DESCRIPTION
## Summary
- use `VernonNext` in `App.tsx`
- remove `VernonNext` from the index page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c06c5810832aa54b2e93dd3fd990