### PR TITLE
Use Perplexity chat and Deepgram voice

### DIFF
--- a/src/components/VernonChat/hooks/useElevenLabsConversation.tsx
+++ b/src/components/VernonChat/hooks/useElevenLabsConversation.tsx
@@ -4,7 +4,7 @@ import { Message } from '../types';
 import { toast } from 'sonner';
 import { useSpeechSynthesis } from './useSpeechSynthesis';
 import { useSpeechRecognition } from './speechRecognition';
-import { VertexAIService } from '@/services/VertexAIService';
+import { PerplexityService } from '@/services/PerplexityService';
 import { SearchService } from '@/services/search/SearchService';
 
 // Create a welcome message based on the mode
@@ -104,15 +104,8 @@ export const useElevenLabsConversation = (isVenueMode: boolean = false) => {
         setMessages(prev => [...prev, aiMessage]);
         return aiMessage.content;
       } else {
-        // Format messages for Vertex AI
-        const contextMessages = messages.slice(-6);
-        
-        // Generate response from Vertex AI
-        const aiResponse = await VertexAIService.generateResponse(
-          voiceText,
-          isVenueMode ? 'venue' : 'default',
-          contextMessages
-        );
+        // Generate response from Perplexity
+        const aiResponse = await PerplexityService.generateResponse(voiceText);
         
         const aiMessage: Message = {
           id: (Date.now() + 1).toString(),
@@ -180,12 +173,8 @@ export const useElevenLabsConversation = (isVenueMode: boolean = false) => {
         // Format messages for Vertex AI
         const contextMessages = messages.slice(-6);
         
-        // Generate response from Vertex AI
-        const aiResponse = await VertexAIService.generateResponse(
-          text,
-          isVenueMode ? 'venue' : 'default',
-          contextMessages
-        );
+        // Generate response from Perplexity
+        const aiResponse = await PerplexityService.generateResponse(text);
         
         const aiMessage: Message = {
           id: (Date.now() + 1).toString(),

--- a/src/components/VernonChat/hooks/useEnhancedVernonChat.ts
+++ b/src/components/VernonChat/hooks/useEnhancedVernonChat.ts
@@ -136,7 +136,7 @@ export const useEnhancedVernonChat = () => {
     if (messages.length === 0) {
       const timestamp = new Date();
       const welcomeMsg =
-        "Hello! I'm Vernon, your AI assistant powered by Google Gemini. How can I help you discover venues and events today?";
+        "Hello! I'm Vernon, your AI assistant powered by Perplexity. How can I help you discover venues and events today?";
 
       setMessages([
         {

--- a/src/components/VernonChat/hooks/useEnhancedVernonChatStore.ts
+++ b/src/components/VernonChat/hooks/useEnhancedVernonChatStore.ts
@@ -97,7 +97,7 @@ export const useEnhancedVernonChatStore = () => {
 
   const initializeWelcomeMessage = useCallback(() => {
     if (chatState.messages.length === 0) {
-      const welcomeMsg = 'Hello! I\'m Vernon, your AI assistant powered by Google Gemini. How can I help you discover venues and events today?';
+      const welcomeMsg = 'Hello! I\'m Vernon, your AI assistant powered by Perplexity. How can I help you discover venues and events today?';
       addChatMessage(welcomeMsg, 'incoming', true);
     }
   }, [chatState.messages.length, addChatMessage]);

--- a/src/components/VernonChat/hooks/useMessageProcessor.ts
+++ b/src/components/VernonChat/hooks/useMessageProcessor.ts
@@ -1,7 +1,7 @@
 
 import { useState, useCallback } from 'react';
 import { Message, ChatMode } from '../types';
-import { VertexAIService } from '@/services/VertexAIService';
+import { PerplexityService } from '@/services/PerplexityService';
 
 export const useMessageProcessor = () => {
   const [isProcessing, setIsProcessing] = useState(false);
@@ -21,14 +21,10 @@ export const useMessageProcessor = () => {
           text: msg.content || msg.text || ''
         }));
         
-        // Use VertexAI for all message processing
-        const response = await VertexAIService.generateResponse(
-          query, 
-          chatMode === 'venue' ? 'venue' : 'default',
-          context
-        );
-        
-        console.log("Received response from VertexAI:", response.substring(0, 50) + "...");
+        // Use Perplexity for message processing
+        const response = await PerplexityService.generateResponse(query);
+
+        console.log("Received response from Perplexity:", response.substring(0, 50) + "...");
         return response;
       } catch (error) {
         console.error('Error processing message:', error);

--- a/src/components/VernonChat/utils/handlers/search/strategies/LocationSearchStrategy.ts
+++ b/src/components/VernonChat/utils/handlers/search/strategies/LocationSearchStrategy.ts
@@ -1,6 +1,6 @@
 
 import { SearchStrategy, SearchOptions } from '../types';
-import { VertexAIService } from '@/services/VertexAIService';
+import { PerplexityService } from '@/services/PerplexityService';
 import { extractCategories } from '@/services/VertexAI/analysis';
 import { cleanResponseText } from '../../../responseFormatter';
 
@@ -30,8 +30,8 @@ export class LocationSearchStrategy implements SearchStrategy {
         }
       }
 
-      // Use VertexAI for location-based search
-      const result = await VertexAIService.searchWithVertex(query, extractedCategories);
+      // Use Perplexity for location-based search
+      const result = await PerplexityService.searchPerplexity(query);
       
       if (result && result.length > 100) {
         const exploreLinkText = "\n\nYou can also [view all these results on our Explore page](/explore?q=" + 

--- a/src/components/VernonChat/utils/messageProcessor/processors/AIProcessor.ts
+++ b/src/components/VernonChat/utils/messageProcessor/processors/AIProcessor.ts
@@ -1,6 +1,6 @@
 
 import { MessageContext, MessageProcessor, ProcessingResult } from '../types';
-import { VertexAIService } from '@/services/VertexAIService';
+import { PerplexityService } from '@/services/PerplexityService';
 import { createAIMessage } from '../../messageFactory';
 
 export class AIProcessor implements MessageProcessor {
@@ -18,14 +18,10 @@ export class AIProcessor implements MessageProcessor {
       let responseText = '';
       
       try {
-        responseText = await VertexAIService.generateResponse(
-          context.query, 
-          context.isVenueMode ? 'venue' : 'default',
-          contextMessages
-        );
-        console.log('Got response from Vertex AI:', responseText.substring(0, 50) + '...');
+        responseText = await PerplexityService.generateResponse(context.query);
+        console.log('Got response from Perplexity:', responseText.substring(0, 50) + '...');
       } catch (error) {
-        console.error('Error with Vertex AI:', error);
+        console.error('Error with Perplexity:', error);
         responseText = "I'm having trouble connecting to my AI services right now. Please try again later.";
       }
       

--- a/src/services/search/SearchService.ts
+++ b/src/services/search/SearchService.ts
@@ -1,6 +1,5 @@
 
-import { GoogleVertexProvider } from './providers/GoogleVertexProvider';
-import { VertexAIService } from '@/services/VertexAIService';
+import { PerplexityService } from '@/services/PerplexityService';
 
 /**
  * Unified search service that coordinates between multiple search providers
@@ -15,22 +14,10 @@ export class SearchService {
     console.log('Searching with query:', query);
     
     try {
-      // Try Google Vertex AI first
-      const vertexResult = await GoogleVertexProvider.search(query);
-      if (vertexResult) {
-        console.log('Got result from Google Vertex AI');
-        return vertexResult;
-      }
-      
-      // Fall back to a direct call to Vertex AI service
-      try {
-        const vertexServiceResult = await VertexAIService.searchWithVertex(query);
-        if (vertexServiceResult) {
-          console.log('Got result from VertexAIService search');
-          return vertexServiceResult;
-        }
-      } catch (vertexError) {
-        console.error('Error with VertexAIService search:', vertexError);
+      // Use Perplexity as the primary search provider
+      const perplexityResult = await PerplexityService.searchPerplexity(query);
+      if (perplexityResult) {
+        return perplexityResult;
       }
       
       // Fall back to a generic response if all searches fail
@@ -49,8 +36,8 @@ export class SearchService {
       // Enhance the query to focus on comedy
       const enhancedQuery = `comedy events: ${query}`;
       
-      // Use Vertex AI's contextual search
-      return await VertexAIService.searchWithVertex(enhancedQuery, ['Comedy', 'Entertainment']);
+      // Use Perplexity for contextual search
+      return await PerplexityService.searchPerplexity(enhancedQuery);
     } catch (error) {
       console.error('Error in comedy search:', error);
       return await this.search(query);
@@ -62,7 +49,6 @@ export class SearchService {
    */
   static async vectorSearch(query: string, filters?: any): Promise<string> {
     try {
-      // Use Google's NLP capabilities through Vertex AI
       const categories = filters?.categories || [];
       
       // Create a more detailed search prompt
@@ -76,7 +62,7 @@ export class SearchService {
         - Any other relevant details
       `;
       
-      return await VertexAIService.generateResponse(searchPrompt, 'search');
+      return await PerplexityService.generateResponse(searchPrompt);
     } catch (error) {
       console.error('Error in vector search:', error);
       return await this.search(query);

--- a/src/services/search/comedy/ComedySearchService.ts
+++ b/src/services/search/comedy/ComedySearchService.ts
@@ -1,5 +1,5 @@
 
-import { VertexAIService } from '@/services/VertexAIService';
+import { PerplexityService } from '@/services/PerplexityService';
 
 /**
  * Service for searching comedy shows and events
@@ -31,18 +31,15 @@ export const ComedySearchService = {
         Return the information in a well-formatted, easy to read format.
       `;
       
-      // Use VertexAI for both search and context-aware responses
-      const comedyInfo = await VertexAIService.searchWithVertex(
-        enhancedQuery,
-        ['entertainment', 'comedy', 'events']
-      );
+      // Use Perplexity for both search and context-aware responses
+      const comedyInfo = await PerplexityService.searchPerplexity(enhancedQuery);
       
       if (comedyInfo && comedyInfo.length > 0) {
         return comedyInfo;
       }
       
       // Fallback to general AI response if search doesn't yield results
-      return VertexAIService.generateResponse(query, 'default');
+      return PerplexityService.generateResponse(query);
     } catch (error) {
       console.error('Error searching for comedy events:', error);
       return 'I apologize, but I had trouble finding comedy events. Please try asking in a different way or check back later.';

--- a/src/services/search/providers/GoogleVertexProvider.ts
+++ b/src/services/search/providers/GoogleVertexProvider.ts
@@ -1,5 +1,5 @@
 
-import { VertexAIService } from '@/services/VertexAIService';
+import { PerplexityService } from '@/services/PerplexityService';
 
 /**
  * Google Vertex AI / Gemini search provider implementation
@@ -10,9 +10,9 @@ export const GoogleVertexProvider = {
    */
   async search(query: string): Promise<string | null> {
     try {
-      console.log('Searching with Google Vertex AI:', query);
-      
-      const result = await VertexAIService.searchWithVertex(query);
+      console.log('Searching with Perplexity:', query);
+
+      const result = await PerplexityService.searchPerplexity(query);
       return result || null;
     } catch (error) {
       console.error('Error with Google Vertex search:', error);

--- a/src/services/search/providers/OpenAISearchProvider.ts
+++ b/src/services/search/providers/OpenAISearchProvider.ts
@@ -1,5 +1,5 @@
 
-import { VertexAIService } from '@/services/VertexAIService';
+import { PerplexityService } from '@/services/PerplexityService';
 
 /**
  * OpenAI search provider implementation - now proxied through Google Vertex AI
@@ -12,8 +12,8 @@ export const OpenAISearchProvider = {
     try {
       console.log('Searching with OpenAI (via Google Vertex AI):', query);
       
-      // Use VertexAIService for search instead of direct OpenAI calls
-      const result = await VertexAIService.searchWithVertex(query);
+      // Use Perplexity for search instead of direct OpenAI calls
+      const result = await PerplexityService.searchPerplexity(query);
       return result || null;
     } catch (error) {
       console.error('Error with OpenAI search (via Vertex AI):', error);


### PR DESCRIPTION
## Summary
- route chat completions through Perplexity instead of Gemini
- prefer Perplexity for search workflows
- use Deepgram for text to speech with browser fallback
- update hooks and welcome text to mention Perplexity

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c6fbb9f8832a9633af8be92740af