### PR TITLE
Use env vars for AI keys

### DIFF
--- a/supabase/functions/openai-chat/.env.local.example
+++ b/supabase/functions/openai-chat/.env.local.example
@@ -1,3 +1,9 @@
 
 # OpenAI API key - replace with your actual key
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Perplexity AI API key
+PERPLEXITY_API_KEY=pplx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Vertex AI API key
+VERTEX_AI_API_KEY=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/supabase/functions/openai-speech/.env.local.example
+++ b/supabase/functions/openai-speech/.env.local.example
@@ -1,3 +1,9 @@
 
 # OpenAI API key - replace with your actual key
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Perplexity AI API key
+PERPLEXITY_API_KEY=pplx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Vertex AI API key
+VERTEX_AI_API_KEY=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/supabase/functions/perplexity-search/index.ts
+++ b/supabase/functions/perplexity-search/index.ts
@@ -6,7 +6,7 @@ import { validateRequired } from "../_shared/validation.ts";
 import { getApiKey, createAuthHeaders } from "../_shared/auth.ts";
 import { logInfo, logError } from "../_shared/logging.ts";
 
-const PERPLEXITY_API_KEY = "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";
+const PERPLEXITY_API_KEY = Deno.env.get('PERPLEXITY_API_KEY');
 
 const handler = withErrorHandling(async (req: Request): Promise<Response> => {
   if (!PERPLEXITY_API_KEY) {

--- a/supabase/functions/vertex-ai/index.ts
+++ b/supabase/functions/vertex-ai/index.ts
@@ -7,8 +7,8 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-// Use the provided API key
-const VERTEX_AI_API_KEY = "AIzaSyDHBe4hL8fQZdz9wSYi9srL0BGTnZ6XmyM";
+// Vertex AI API key from environment variable
+const VERTEX_AI_API_KEY = Deno.env.get('VERTEX_AI_API_KEY');
 
 // Available models with proper fallback logic
 const MODELS = {
@@ -20,6 +20,13 @@ serve(async (req) => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
+  }
+
+  if (!VERTEX_AI_API_KEY) {
+    return new Response(
+      JSON.stringify({ error: 'Vertex AI API key not configured' }),
+      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
   }
 
   try {


### PR DESCRIPTION
## Summary
- load Perplexity API key from environment
- read Vertex AI key from environment and handle when missing
- document new env vars in sample files

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859dc567470832ab25a55ce0147eda1