### PR TITLE
Switch Gemini UI references to Perplexity

### DIFF
--- a/src/components/VernonChat/components/ChatSettings.tsx
+++ b/src/components/VernonChat/components/ChatSettings.tsx
@@ -89,7 +89,7 @@ const ChatSettings: React.FC<ChatSettingsProps> = ({
         
         <DropdownMenuSeparator className="bg-gray-700" />
         <DropdownMenuItem className="text-xs text-center justify-center text-gray-400">
-          Powered by Gemini
+          Powered by Perplexity
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/VernonNext/ChatWindow.tsx
+++ b/src/components/VernonNext/ChatWindow.tsx
@@ -146,7 +146,7 @@ const ChatWindow: React.FC<ChatWindowProps> = ({
             <h2 className="text-white font-medium flex items-center">
               Vernon
               <Badge variant="outline" className="ml-2 bg-blue-700 text-white border-blue-500 text-xs px-1.5">
-                Gemini
+                Perplexity
               </Badge>
             </h2>
             <p className="text-blue-100 text-xs">AI Assistant</p>

--- a/src/components/VertexAIDemoPanel.tsx
+++ b/src/components/VertexAIDemoPanel.tsx
@@ -87,9 +87,9 @@ const VertexAIDemoPanel = () => {
   return (
     <Card className="w-full max-w-3xl mx-auto">
       <CardHeader>
-        <CardTitle>Vertex AI Demo</CardTitle>
+        <CardTitle>Perplexity AI Demo</CardTitle>
         <CardDescription>
-          Test various Vertex AI capabilities
+          Test various Perplexity AI capabilities
         </CardDescription>
       </CardHeader>
       
@@ -145,7 +145,7 @@ const VertexAIDemoPanel = () => {
       
       <CardFooter className="flex justify-between">
         <p className="text-sm text-muted-foreground">
-          Powered by Google Vertex AI
+          Powered by Perplexity
         </p>
       </CardFooter>
     </Card>

--- a/src/components/data-insights/PremiumBanner.tsx
+++ b/src/components/data-insights/PremiumBanner.tsx
@@ -68,7 +68,7 @@ const PremiumBanner = ({ onUpgrade }: PremiumBannerProps) => {
             <div className="space-y-3 text-center text-sm text-muted-foreground">
               <div className="flex items-center justify-center">
                 <BarChart className="mr-2 h-4 w-4 text-green-400" />
-                Gemini Deep Research Analytics
+                Perplexity Research Analytics
               </div>
               <div className="flex items-center justify-center">
                 <Target className="mr-2 h-4 w-4 text-green-400" />
@@ -79,7 +79,7 @@ const PremiumBanner = ({ onUpgrade }: PremiumBannerProps) => {
                 Notebook LM Podcast Reports
               </div>
               <p className="text-xs">
-                Access detailed insights powered by Google's Gemini AI about visitor demographics and behavior patterns, create targeted promotions and track their performance in real-time, and generate AI-powered podcast summaries of your weekly insights using Google Notebook LM
+                Access detailed insights powered by Perplexity about visitor demographics and behavior patterns, create targeted promotions and track their performance in real-time, and generate AI-powered podcast summaries of your weekly insights using Google Notebook LM
               </p>
             </div>
             <div className="text-center mt-4">
@@ -115,7 +115,7 @@ const PremiumBanner = ({ onUpgrade }: PremiumBannerProps) => {
                 Influencer Marketplace
               </div>
               <p className="text-xs">
-                Everything in Plus and Premium, plus AI-Powered Gemini analysis of uploaded financial records, access to Google's Veo and Imagen AI models to create ads and videos for marketing campaigns, and access to the Influencer Marketplace
+                Everything in Plus and Premium, plus AI-powered Perplexity analysis of uploaded financial records, access to Google's Veo and Imagen AI models to create ads and videos for marketing campaigns, and access to the Influencer Marketplace
               </p>
             </div>
             <div className="text-center mt-4">
@@ -132,7 +132,7 @@ const PremiumBanner = ({ onUpgrade }: PremiumBannerProps) => {
             Upgrade to Pro
           </Button>
           <p className="text-xs text-muted-foreground mt-4 max-w-2xl mx-auto">
-            All plans include basic venue profile features. Upgrade to Pro for access to Google's cutting-edge Gemini, Veo, Imagen, 
+            All plans include basic venue profile features. Upgrade to Pro for access to cutting-edge Perplexity, Veo, Imagen,
             and Notebook LM technologies to grow your business. Project Mariner handles bookings automatically. Annual billing 
             available with a 15% discount.
           </p>

--- a/src/components/venue/VernonReviewChat.tsx
+++ b/src/components/venue/VernonReviewChat.tsx
@@ -52,7 +52,7 @@ const VernonReviewChat: React.FC<VernonReviewChatProps> = ({
     setIsLoading(true);
 
     try {
-      // Call Gemini via our existing edge function
+      // Call Perplexity via our existing edge function
       const { data, error } = await supabase.functions.invoke('gemini-ai', {
         body: {
           prompt: `Based on the following ${platform} review summary for a venue, please answer this question: "${messageText}"

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -3,7 +3,6 @@
 export { DeepgramService } from './Deepgram';
 export { VertexAIService } from './VertexAIService';
 export { OpenAIService } from './OpenAIService';
-export { GeminiService } from './GeminiService';
 export { SocialMediaAggregator } from './socialMedia/aggregator';
 
 // Service types

--- a/src/services/search/providers/IntegratedSearchProvider.ts
+++ b/src/services/search/providers/IntegratedSearchProvider.ts
@@ -1,7 +1,6 @@
 
 import { SimpleSearchService } from '../SimpleSearchService';
 import { SwirlSearchService } from '@/services/SwirlSearchService';
-import { GeminiService } from '@/services/GeminiService';
 import { VertexAIHub } from '@/services/VertexAI';
 import { 
   OpenAISearchProvider,


### PR DESCRIPTION
## Summary
- show a Perplexity badge in the Vernon chat window
- clarify Perplexity usage across the premium banner and chat settings
- rename Vertex AI demo text to Perplexity
- update comments and remove unused Gemini service export

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859e00de1c4832a8fbc0f3f45f367ef