### PR TITLE
Load API keys from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,13 @@ We don't support custom domains (yet). If you want to deploy your project under 
 Some Supabase Edge Functions in this repo use Deepgram for text-to-speech. These functions expect a `DEEPGRAM_API_KEY` environment variable to be available.
 
 Make sure **not** to commit your API key to the repository. Add the key to a `.env` file for local development or provide it in your deployment dashboard when you deploy the functions.
+
+## Additional API keys
+
+Other Supabase functions and the front-end require extra keys. Create a `.env` file (or `.env.local` inside each function directory) and set these variables locally:
+
+- `GEMINI_API_KEY` – used by the image generation and review sentiment functions
+- `OPENROUTER_API_KEY` – used by the `openai-chat` function
+- `GOOGLE_MAPS_API_KEY` – used by the map components and city detection logic
+
+These values should also be configured in your deployment environment.

--- a/src/components/TrendingLocations.tsx
+++ b/src/components/TrendingLocations.tsx
@@ -9,6 +9,8 @@ import { mockLocations } from "@/mock/locations";
 import { getTrendingLocationsForCity } from "@/mock/cityLocations";
 import { toast } from "sonner";
 
+const GOOGLE_MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+
 // Event bus for updating trending locations from VernonChat
 export const eventBus = {
   listeners: new Map<string, Function[]>(),
@@ -48,7 +50,7 @@ const TrendingLocations = () => {
           try {
             // Use Google's Geocoding API to get the city name from coordinates
             const response = await fetch(
-              `https://maps.googleapis.com/maps/api/geocode/json?latlng=${position.coords.latitude},${position.coords.longitude}&key=AIzaSyAWm0vayRrQJHpMc6XcShcge52hGTt9BV4`
+              `https://maps.googleapis.com/maps/api/geocode/json?latlng=${position.coords.latitude},${position.coords.longitude}&key=${GOOGLE_MAPS_API_KEY}`
             );
             
             if (response.ok) {

--- a/src/components/map/GoogleMap.tsx
+++ b/src/components/map/GoogleMap.tsx
@@ -8,8 +8,8 @@ import { Button } from "@/components/ui/button";
 import { Navigation, Pin, Compass } from "lucide-react";
 import { toast } from "sonner";
 
-// Google Maps API key - in production, this should be stored in environment variables
-const GOOGLE_MAPS_API_KEY = "AIzaSyDIwf3LDvHPDNR3A5s1jWu_-o4Zat4f6TY";
+// Google Maps API key loaded from Vite environment variables
+const GOOGLE_MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 
 const mapContainerStyle = {
   width: '100%',

--- a/src/components/map/google/useGoogleMap.tsx
+++ b/src/components/map/google/useGoogleMap.tsx
@@ -2,8 +2,8 @@ import { useState, useCallback, useEffect } from 'react';
 import { useJsApiLoader } from '@react-google-maps/api';
 import { Location } from "@/types";
 
-// Google Maps API key
-const GOOGLE_MAPS_API_KEY = "AIzaSyAWm0vayRrQJHpMc6XcShcge52hGTt9BV4";
+// Google Maps API key loaded from Vite environment variables
+const GOOGLE_MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 
 export const useGoogleMap = (
   userLocation: GeolocationCoordinates | null, 

--- a/src/hooks/explore/useCityDetection.ts
+++ b/src/hooks/explore/useCityDetection.ts
@@ -1,6 +1,8 @@
 
 import { useEffect } from "react";
 
+const GOOGLE_MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+
 export const useCityDetection = (
   setSearchQuery: (query: string) => void,
   setSearchedCity: (city: string) => void,
@@ -14,7 +16,7 @@ export const useCityDetection = (
         async (position) => {
           try {
             const response = await fetch(
-              `https://maps.googleapis.com/maps/api/geocode/json?latlng=${position.coords.latitude},${position.coords.longitude}&key=AIzaSyAWm0vayRrQJHpMc6XcShcge52hGTt9BV4`
+              `https://maps.googleapis.com/maps/api/geocode/json?latlng=${position.coords.latitude},${position.coords.longitude}&key=${GOOGLE_MAPS_API_KEY}`
             );
             
             if (!response.ok) return;

--- a/src/services/OpenRouterService.ts
+++ b/src/services/OpenRouterService.ts
@@ -20,7 +20,8 @@ interface TextToSpeechOptions {
 }
 
 export const OpenRouterService = {
-  apiKey: "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",
+  // API key is loaded from Vite environment variables
+  apiKey: import.meta.env.VITE_OPENROUTER_API_KEY || '',
   baseUrl: "https://openrouter.ai/api/v1",
 
   async getCompletion({

--- a/supabase/functions/gemini-imagen/index.ts
+++ b/supabase/functions/gemini-imagen/index.ts
@@ -1,7 +1,8 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 
-const GEMINI_API_KEY = "AIzaSyBeEJvxSAjyvoRS6supoob0F7jGW7lhZUU";
+// Gemini Imagen API key is provided via environment variables
+const GEMINI_API_KEY = Deno.env.get('GEMINI_API_KEY');
 const IMAGEN_API_URL = "https://generativelanguage.googleapis.com/v1/models/imagegeneration:generateImage";
 
 const corsHeaders = {
@@ -16,6 +17,13 @@ serve(async (req) => {
   }
 
   try {
+    if (!GEMINI_API_KEY) {
+      return new Response(
+        JSON.stringify({ error: 'Gemini API key not configured' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
     const { prompt } = await req.json();
     
     console.log("Generating image with prompt:", prompt);

--- a/supabase/functions/openai-chat/index.ts
+++ b/supabase/functions/openai-chat/index.ts
@@ -7,7 +7,8 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-const OPENROUTER_API_KEY = "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";
+// API key for OpenRouter is loaded from the environment
+const OPENROUTER_API_KEY = Deno.env.get('OPENROUTER_API_KEY');
 
 serve(async (req) => {
   // Handle CORS preflight requests
@@ -16,6 +17,13 @@ serve(async (req) => {
   }
 
   try {
+    if (!OPENROUTER_API_KEY) {
+      return new Response(
+        JSON.stringify({ error: 'OpenRouter API key not configured' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
     const { messages, model = "anthropic/claude-3-haiku", stream = false, context = "user", useOpenRouter = true } = await req.json();
 
     // Add system prompt based on context

--- a/supabase/functions/review-sentiment-analyzer/index.ts
+++ b/supabase/functions/review-sentiment-analyzer/index.ts
@@ -6,8 +6,8 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-// Use the Gemini API key for sentiment analysis
-const GEMINI_API_KEY = "AIzaSyCfJFLglZMGwe2j-XbYtbHKB8-xN15PXZM";
+// Gemini API key loaded from environment variables
+const GEMINI_API_KEY = Deno.env.get('GEMINI_API_KEY');
 
 serve(async (req) => {
   // Handle CORS preflight requests
@@ -16,6 +16,13 @@ serve(async (req) => {
   }
 
   try {
+    if (!GEMINI_API_KEY) {
+      return new Response(
+        JSON.stringify({ error: 'Gemini API key not configured' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
     const { venue_id, platform, reviews } = await req.json();
 
     if (!venue_id || !platform || !reviews || !Array.isArray(reviews)) {


### PR DESCRIPTION
## Summary
- remove hard-coded API keys from Supabase functions
- use `import.meta.env` or `Deno.env.get` for all API keys
- update map components and hooks to read Google Maps key from environment
- note required environment variables in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859e336ed64832aa08f7a1fcefd2ac9