### PR TITLE
Unify speech synthesis hooks

### DIFF
--- a/src/components/VernonChat/hooks/speechSynthesis/index.ts
+++ b/src/components/VernonChat/hooks/speechSynthesis/index.ts
@@ -1,6 +1,6 @@
 
-// Export the main optimized hook
-export { useOptimizedSpeechSynthesis } from './useOptimizedSpeechSynthesis';
+// Export the unified Deepgram-based hook
+export { useDeepgramSpeechSynthesis } from './useDeepgramSpeechSynthesis';
 
 // Export legacy hooks for backward compatibility
 export { useSpeechSynthesis } from '../useSpeechSynthesis';
@@ -8,7 +8,6 @@ export { useSpeechSynthesisCore } from './useSpeechSynthesisCore';
 export { useSpeakResponse } from './useSpeakResponse';
 export { useElevenLabsKeyManager } from './useElevenLabsKeyManager';
 export { useSpeechSynthesisVoices } from './useSpeechSynthesisVoices';
-export { useDeepgramVoice } from './useDeepgramVoice';
 export { useBrowserSpeechSynthesis } from './useBrowserSpeechSynthesis';
 export { useDeepgramSpeech } from './useDeepgramSpeech';
 

--- a/src/components/VernonChat/hooks/speechSynthesis/useDeepgramSpeechSynthesis.ts
+++ b/src/components/VernonChat/hooks/speechSynthesis/useDeepgramSpeechSynthesis.ts
@@ -1,0 +1,106 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { DeepgramService } from '@/services';
+
+export const useDeepgramSpeechSynthesis = () => {
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  const [isDeepgramReady, setIsDeepgramReady] = useState<boolean>(DeepgramService.hasApiKey());
+  const currentUtterance = useRef<SpeechSynthesisUtterance | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const promptForDeepgramKey = useCallback(() => {
+    const apiKey = prompt('Enter your Deepgram API key for improved voice quality:');
+    if (apiKey) {
+      DeepgramService.setApiKey(apiKey);
+      setIsDeepgramReady(true);
+    }
+  }, []);
+
+  const stop = useCallback(() => {
+    if (currentUtterance.current) {
+      window.speechSynthesis.cancel();
+      currentUtterance.current = null;
+    }
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current = null;
+    }
+    setIsSpeaking(false);
+  }, []);
+
+  const speak = useCallback(async (text: string): Promise<boolean> => {
+    if (!text || text.trim() === '') return false;
+    stop();
+
+    try {
+      setIsSpeaking(true);
+      const audioData = await DeepgramService.textToSpeech(text);
+      if (audioData) {
+        const blob = new Blob([audioData], { type: 'audio/mpeg' });
+        const url = URL.createObjectURL(blob);
+        const audio = new Audio(url);
+        audioRef.current = audio;
+        return await new Promise<boolean>((resolve) => {
+          audio.onended = () => {
+            URL.revokeObjectURL(url);
+            setIsSpeaking(false);
+            resolve(true);
+          };
+          audio.onerror = () => {
+            URL.revokeObjectURL(url);
+            setIsSpeaking(false);
+            resolve(false);
+          };
+          audio.play().catch(() => {
+            URL.revokeObjectURL(url);
+            setIsSpeaking(false);
+            resolve(false);
+          });
+        });
+      }
+
+      const utterance = new SpeechSynthesisUtterance(text);
+      currentUtterance.current = utterance;
+      const voices = window.speechSynthesis.getVoices();
+      const preferredVoice = voices.find(voice =>
+        voice.lang.includes('en') &&
+        (voice.name.includes('Male') ||
+         voice.name.includes('David') ||
+         voice.name.includes('Daniel') ||
+         voice.name.includes('Google UK English Male'))
+      );
+      if (preferredVoice) {
+        utterance.voice = preferredVoice;
+      }
+      utterance.rate = 0.9;
+      utterance.pitch = 0.8;
+      utterance.onend = () => {
+        setIsSpeaking(false);
+        currentUtterance.current = null;
+      };
+      utterance.onerror = () => {
+        setIsSpeaking(false);
+        currentUtterance.current = null;
+      };
+      window.speechSynthesis.speak(utterance);
+      return true;
+    } catch (error) {
+      console.error('Speech synthesis error:', error);
+      setIsSpeaking(false);
+      return false;
+    }
+  }, [stop]);
+
+  useEffect(() => {
+    return () => {
+      stop();
+    };
+  }, [stop]);
+
+  return {
+    speak,
+    stop,
+    isSpeaking,
+    isDeepgramReady,
+    promptForDeepgramKey
+  };
+};

--- a/src/components/VernonChat/hooks/useEnhancedVernonChat.ts
+++ b/src/components/VernonChat/hooks/useEnhancedVernonChat.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from "react";
 import { useLocalStorage } from "./useLocalStorage";
 import { useMessageProcessor } from "./useMessageProcessor";
 import { useOptimizedSpeechRecognition } from "./speechRecognition/useOptimizedSpeechRecognition";
-import { useOptimizedSpeechSynthesis } from "./speechSynthesis/useOptimizedSpeechSynthesis";
+import { useDeepgramSpeechSynthesis } from "./speechSynthesis/useDeepgramSpeechSynthesis";
 import { Message, MessageDirection, ChatMode } from "../types";
 
 export const useEnhancedVernonChat = () => {
@@ -24,7 +24,7 @@ export const useEnhancedVernonChat = () => {
     speak,
     stop: stopSpeaking,
     isSpeaking,
-  } = useOptimizedSpeechSynthesis();
+  } = useDeepgramSpeechSynthesis();
   const {
     isListening,
     transcript,

--- a/src/components/VernonChat/hooks/useEnhancedVernonChatStore.ts
+++ b/src/components/VernonChat/hooks/useEnhancedVernonChatStore.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { useChatStore, useUserStore } from '@/store';
 import { useMessageProcessor } from './useMessageProcessor';
 import { useOptimizedSpeechRecognition } from './speechRecognition/useOptimizedSpeechRecognition';
-import { useOptimizedSpeechSynthesis } from './speechSynthesis/useOptimizedSpeechSynthesis';
+import { useDeepgramSpeechSynthesis } from './speechSynthesis/useDeepgramSpeechSynthesis';
 import { Message, MessageDirection } from '../types';
 import { createAIMessage, createUserMessage } from '../utils/messageFactory';
 
@@ -24,7 +24,7 @@ export const useEnhancedVernonChatStore = () => {
   const { processMessage } = useMessageProcessor();
   
   // Use optimized speech hooks
-  const { speak, stop: stopSpeaking, isSpeaking } = useOptimizedSpeechSynthesis();
+  const { speak, stop: stopSpeaking, isSpeaking } = useDeepgramSpeechSynthesis();
   const { 
     isListening, 
     transcript, 


### PR DESCRIPTION
## Summary
- add `useDeepgramSpeechSynthesis` hook with Deepgram+browser support
- export the new hook and drop the old voice exports
- update chat hooks to use the unified speech synthesis
- simplify OpenAI chat hook to rely on the new hook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6859e0ebcb60832a8e14f09733c5c639