### PR TITLE
Use env variables for API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Example environment variables for local development
+
+# API keys for Supabase Edge Functions
+OPENROUTER_API_KEY=your-openrouter-api-key
+PERPLEXITY_API_KEY=your-perplexity-api-key
+GEMINI_API_KEY=your-gemini-api-key
+DEEPGRAM_API_KEY=your-deepgram-api-key
+
+# Front-end keys (Vite uses the VITE_ prefix)
+VITE_OPENROUTER_API_KEY=your-openrouter-api-key
+VITE_GOOGLE_MAPS_API_KEY=your-google-maps-key

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Other Supabase functions and the front-end require extra keys. Create a `.env` f
 
 - `GEMINI_API_KEY` – used by the image generation and review sentiment functions
 - `OPENROUTER_API_KEY` – used by the `openai-chat` function
+- `PERPLEXITY_API_KEY` – used by the `perplexity-search` function
+- `VITE_OPENROUTER_API_KEY` – required by the front-end `OpenRouterService`
 - `GOOGLE_MAPS_API_KEY` – used by the map components and city detection logic
 
 These values should also be configured in your deployment environment.

--- a/src/services/OpenRouterService.ts
+++ b/src/services/OpenRouterService.ts
@@ -20,9 +20,11 @@ interface TextToSpeechOptions {
 }
 
 export const OpenRouterService = {
-  // API key is loaded from Vite environment variables
+  // API key and other values loaded from Vite environment variables
   apiKey: import.meta.env.VITE_OPENROUTER_API_KEY || '',
-  baseUrl: "https://openrouter.ai/api/v1",
+  baseUrl: import.meta.env.VITE_OPENROUTER_API_BASE_URL || 'https://openrouter.ai/api/v1',
+  referer: import.meta.env.VITE_OPENROUTER_REFERER || window.location.origin,
+  title: import.meta.env.VITE_OPENROUTER_TITLE || 'VibesApp',
 
   async getCompletion({
     prompt,
@@ -41,8 +43,8 @@ export const OpenRouterService = {
         headers: {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${this.apiKey}`,
-          'HTTP-Referer': window.location.origin,
-          'X-Title': 'VibesApp'
+          'HTTP-Referer': this.referer,
+          'X-Title': this.title
         },
         body: JSON.stringify({
           model,
@@ -108,8 +110,8 @@ export const OpenRouterService = {
         headers: {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${this.apiKey}`,
-          'HTTP-Referer': window.location.origin,
-          'X-Title': 'VibesApp'
+          'HTTP-Referer': this.referer,
+          'X-Title': this.title
         },
         body: JSON.stringify({
           model: "anthropic/claude-3-opus",
@@ -163,8 +165,8 @@ export const OpenRouterService = {
         headers: {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${this.apiKey}`,
-          'HTTP-Referer': window.location.origin,
-          'X-Title': 'VibesApp'
+          'HTTP-Referer': this.referer,
+          'X-Title': this.title
         },
         body: JSON.stringify({
           model: "anthropic/claude-3-sonnet",
@@ -218,8 +220,8 @@ export const OpenRouterService = {
         headers: {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${this.apiKey}`,
-          'HTTP-Referer': window.location.origin,
-          'X-Title': 'VibesApp'
+          'HTTP-Referer': this.referer,
+          'X-Title': this.title
         },
         body: JSON.stringify({
           model: options.model || "anthropic/claude-3-haiku",

--- a/supabase/functions/openai-chat/index.ts
+++ b/supabase/functions/openai-chat/index.ts
@@ -7,8 +7,11 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-// API key for OpenRouter is loaded from the environment
+// Configuration values for OpenRouter
 const OPENROUTER_API_KEY = Deno.env.get('OPENROUTER_API_KEY');
+const OPENROUTER_API_BASE_URL = Deno.env.get('OPENROUTER_API_BASE_URL') || 'https://openrouter.ai/api/v1';
+const OPENROUTER_REFERER = Deno.env.get('OPENROUTER_REFERER') || 'https://vibe-right-now.web.app';
+const OPENROUTER_TITLE = Deno.env.get('OPENROUTER_TITLE') || 'Vibe Right Now';
 
 serve(async (req) => {
   // Handle CORS preflight requests
@@ -63,13 +66,13 @@ Do not express personal opinions or beliefs. Focus solely on providing informati
     });
     
     // Use OpenRouter for open-source models
-    const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+    const response = await fetch(`${OPENROUTER_API_BASE_URL}/chat/completions`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "Authorization": `Bearer ${OPENROUTER_API_KEY}`,
-        "HTTP-Referer": "https://vibe-right-now.web.app",
-        "X-Title": "Vibe Right Now"
+        "HTTP-Referer": OPENROUTER_REFERER,
+        "X-Title": OPENROUTER_TITLE
       },
       body: JSON.stringify({
         model: model, // Use the passed model or default to Claude Haiku

--- a/supabase/functions/perplexity-search/index.ts
+++ b/supabase/functions/perplexity-search/index.ts
@@ -7,6 +7,7 @@ import { getApiKey, createAuthHeaders } from "../_shared/auth.ts";
 import { logInfo, logError } from "../_shared/logging.ts";
 
 const PERPLEXITY_API_KEY = Deno.env.get('PERPLEXITY_API_KEY');
+const PERPLEXITY_API_URL = Deno.env.get('PERPLEXITY_API_URL') || 'https://api.perplexity.ai/chat/completions';
 
 const handler = withErrorHandling(async (req: Request): Promise<Response> => {
   if (!PERPLEXITY_API_KEY) {
@@ -19,7 +20,7 @@ const handler = withErrorHandling(async (req: Request): Promise<Response> => {
   logInfo(`Searching with Perplexity`, { queryLength: query.length });
 
   const authHeaders = createAuthHeaders(PERPLEXITY_API_KEY);
-  const perplexityResponse = await fetch('https://api.perplexity.ai/chat/completions', {
+  const perplexityResponse = await fetch(PERPLEXITY_API_URL, {
     method: 'POST',
     headers: {
       ...authHeaders,


### PR DESCRIPTION
## Summary
- read keys from environment in OpenRouter supabase function
- use PERPLEXITY_API_URL and key env vars in perplexity search function
- make OpenRouterService configurable with Vite env vars
- document required environment variables
- provide example `.env` file

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859f25e4c80832aaa7458b047d5953b