### PR TITLE
Refactor mobile detection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,9 +25,8 @@ const VenueMessaging = lazy(() => import("@/components/messaging/VenueMessaging"
 const Messages = lazy(() => import("@/pages/Messages"));
 
 function App() {
-  // Add a useEffect to handle mobile view adjustments
+  // Set viewport meta tag on mount
   useEffect(() => {
-    // Set viewport meta tag to ensure proper scaling on mobile devices
     const viewportMeta = document.querySelector('meta[name="viewport"]');
     if (viewportMeta) {
       viewportMeta.setAttribute(
@@ -35,22 +34,6 @@ function App() {
         'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover'
       );
     }
-    
-    // Add a class to the body for mobile-specific styling if needed
-    const handleResize = () => {
-      if (window.innerWidth < 768) {
-        document.body.classList.add('is-mobile');
-      } else {
-        document.body.classList.remove('is-mobile');
-      }
-    };
-    
-    handleResize();
-    window.addEventListener('resize', handleResize);
-    
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
   }, []);
 
   return (

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -3,55 +3,30 @@ import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
 
-export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-  const [orientation, setOrientation] = React.useState<"portrait" | "landscape" | undefined>(undefined)
+const MobileContext = React.createContext(false)
 
-  React.useEffect(() => {
-    // Handle initial detection and resize events
-    const handleResize = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-      setOrientation(
-        window.innerHeight > window.innerWidth ? "portrait" : "landscape"
-      )
-    }
-    
-    // Initialize with current values
-    handleResize()
-    
-    // Setup media query listener for breakpoint detection
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    mql.addEventListener("change", handleResize)
-    
-    // Setup orientation change listener
-    window.addEventListener("resize", handleResize)
-    
-    // Cleanup listeners
-    return () => {
-      mql.removeEventListener("change", handleResize)
-      window.removeEventListener("resize", handleResize)
-    }
-  }, [])
-
-  return !!isMobile
-}
-
-// Export additional hook to get orientation if needed
-export function useOrientation() {
-  const [orientation, setOrientation] = React.useState<"portrait" | "landscape" | undefined>(undefined)
+export const MobileProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [isMobile, setIsMobile] = React.useState(false)
 
   React.useEffect(() => {
     const handleResize = () => {
-      setOrientation(
-        window.innerHeight > window.innerWidth ? "portrait" : "landscape"
-      )
+      const mobile = window.innerWidth < MOBILE_BREAKPOINT
+      setIsMobile(mobile)
+      if (mobile) {
+        document.body.classList.add('is-mobile')
+      } else {
+        document.body.classList.remove('is-mobile')
+      }
     }
-    
+
     handleResize()
-    window.addEventListener("resize", handleResize)
-    
-    return () => window.removeEventListener("resize", handleResize)
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
   }, [])
 
-  return orientation
+  return (
+    <MobileContext.Provider value={isMobile}>{children}</MobileContext.Provider>
+  )
 }
+
+export const useIsMobile = () => React.useContext(MobileContext)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { MobileProvider } from './hooks/use-mobile'
 
 // Ensure we're creating the root element properly
 const rootElement = document.getElementById("root");
@@ -9,7 +10,11 @@ if (!rootElement) throw new Error("Failed to find the root element");
 
 // Adding error boundary at the top level
 try {
-  createRoot(rootElement).render(<App />);
+  createRoot(rootElement).render(
+    <MobileProvider>
+      <App />
+    </MobileProvider>
+  );
 } catch (error) {
   console.error("Failed to render the app:", error);
   // Show a fallback UI instead of a blank screen


### PR DESCRIPTION
## Summary
- create a mobile context and provider
- remove redundant orientation hook
- wrap app with MobileProvider
- drop resize listener in App and rely on context

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c46601a88832a9b5523a2067d6f3e