### PR TITLE
Share scroll direction via context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import VernonNext from '@/components/VernonNext';
 import { Auth0Provider } from "./auth/Auth0Provider";
+import { ScrollDirectionProvider } from "@/providers/ScrollDirectionProvider";
 
 // Lazy-loaded components
 const Index = lazy(() => import("@/pages/Index"));
@@ -56,8 +57,9 @@ function App() {
   return (
     <Auth0Provider>
       <ThemeProvider defaultTheme="light" storageKey="vibe-ui-theme">
-        <BrowserRouter>
-          <Suspense fallback={<div className="h-screen w-screen flex items-center justify-center">Loading...</div>}>
+        <ScrollDirectionProvider>
+          <BrowserRouter>
+            <Suspense fallback={<div className="h-screen w-screen flex items-center justify-center">Loading...</div>}>
             <Routes>
               <Route path="/" element={<Index />} />
               <Route path="/explore" element={<Explore />} />
@@ -81,7 +83,8 @@ function App() {
           </Suspense>
           <VernonNext />
           <Toaster />
-        </BrowserRouter>
+          </BrowserRouter>
+        </ScrollDirectionProvider>
       </ThemeProvider>
     </Auth0Provider>
   );

--- a/src/hooks/useScrollDirection.ts
+++ b/src/hooks/useScrollDirection.ts
@@ -1,24 +1,32 @@
 
-import { useState, useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react'
 
-export const useScrollDirection = () => {
-  const [scrollDirection, setScrollDirection] = useState<'up' | 'down' | 'idle'>('idle');
-  const [lastScrollY, setLastScrollY] = useState(0);
+export const useScrollDirectionInternal = () => {
+  const [scrollDirection, setScrollDirection] = useState<'up' | 'down' | 'idle'>('idle')
+  const lastScrollY = useRef(0)
+  const directionRef = useRef<'up' | 'down' | 'idle'>('idle')
 
   useEffect(() => {
     const updateScrollDirection = () => {
-      const scrollY = window.scrollY;
-      const direction = scrollY > lastScrollY ? 'down' : 'up';
-      
-      if (direction !== scrollDirection && (scrollY - lastScrollY > 10 || scrollY - lastScrollY < -10)) {
-        setScrollDirection(direction);
+      const scrollY = window.scrollY
+      const direction: 'up' | 'down' = scrollY > lastScrollY.current ? 'down' : 'up'
+
+      if (
+        direction !== directionRef.current &&
+        Math.abs(scrollY - lastScrollY.current) > 10
+      ) {
+        directionRef.current = direction
+        setScrollDirection(direction)
       }
-      setLastScrollY(scrollY > 0 ? scrollY : 0);
-    };
 
-    window.addEventListener('scroll', updateScrollDirection);
-    return () => window.removeEventListener('scroll', updateScrollDirection);
-  }, [scrollDirection, lastScrollY]);
+      lastScrollY.current = scrollY > 0 ? scrollY : 0
+    }
 
-  return scrollDirection;
-};
+    window.addEventListener('scroll', updateScrollDirection)
+    return () => window.removeEventListener('scroll', updateScrollDirection)
+  }, [])
+
+  return scrollDirection
+}
+
+export { useScrollDirection } from '../providers/ScrollDirectionProvider'

--- a/src/providers/ScrollDirectionProvider.tsx
+++ b/src/providers/ScrollDirectionProvider.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { useScrollDirectionInternal } from '@/hooks/useScrollDirection'
+
+const ScrollDirectionContext = React.createContext<'up' | 'down' | 'idle'>('idle')
+
+export const ScrollDirectionProvider = ({ children }: { children: React.ReactNode }) => {
+  const direction = useScrollDirectionInternal()
+  return <ScrollDirectionContext.Provider value={direction}>{children}</ScrollDirectionContext.Provider>
+}
+
+export const useScrollDirection = () => React.useContext(ScrollDirectionContext)
+


### PR DESCRIPTION
## Summary
- refactor `useScrollDirection` hook to store `lastScrollY` in a ref and update state only on direction change
- expose a `ScrollDirectionProvider` so multiple components share one listener
- wrap the app with the new provider

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c827fa6a4832a82bcf12ade280e29