### PR TITLE
Unify subscription data

### DIFF
--- a/src/components/venue/VenuePostsList.tsx
+++ b/src/components/venue/VenuePostsList.tsx
@@ -9,7 +9,7 @@ interface VenuePostsListProps {
   venue: Location;
   viewMode: "list" | "grid";
   getComments: (postId: string) => Comment[];
-  subscriptionTier?: 'standard' | 'plus' | 'premium' | 'pro';
+  subscriptionTier?: 'free' | 'plus' | 'premium' | 'pro';
   onPostDeleted?: (postId: string) => void;
 }
 
@@ -18,7 +18,7 @@ const VenuePostsList: React.FC<VenuePostsListProps> = ({
   venue,
   viewMode,
   getComments,
-  subscriptionTier = 'standard',
+  subscriptionTier = 'free',
   onPostDeleted
 }) => {
   const [localPosts, setLocalPosts] = useState<Post[]>(posts);

--- a/src/components/venue/tabs/TabContent.tsx
+++ b/src/components/venue/tabs/TabContent.tsx
@@ -14,7 +14,7 @@ interface TabContentProps {
   venue: Location;
   viewMode: "list" | "grid";
   getComments: (postId: string) => Comment[];
-  subscriptionTier: 'standard' | 'plus' | 'premium' | 'pro';
+  subscriptionTier: 'free' | 'plus' | 'premium' | 'pro';
   canEmbed: boolean;
   connectedPlatforms: Record<string, boolean>;
   onUpgradeSubscription: () => void;

--- a/src/components/venue/tabs/VenuePostsAllTab.tsx
+++ b/src/components/venue/tabs/VenuePostsAllTab.tsx
@@ -8,7 +8,7 @@ interface VenuePostsAllTabProps {
   venue: Location; 
   viewMode: "list" | "grid";
   getComments: (postId: string) => Comment[];
-  subscriptionTier?: 'standard' | 'plus' | 'premium' | 'pro';
+  subscriptionTier?: 'free' | 'plus' | 'premium' | 'pro';
   onPostDeleted?: (postId: string) => void;
 }
 
@@ -17,7 +17,7 @@ const VenuePostsAllTab: React.FC<VenuePostsAllTabProps> = ({
   venue,
   viewMode,
   getComments,
-  subscriptionTier = 'standard',
+  subscriptionTier = 'free',
   onPostDeleted
 }) => {
   return (

--- a/src/components/venue/tabs/VenuePostsExternalTab.tsx
+++ b/src/components/venue/tabs/VenuePostsExternalTab.tsx
@@ -9,7 +9,7 @@ import { SocialMediaApiKeys } from '@/services/SocialMediaService';
 interface VenuePostsExternalTabProps {
   venueName: string;
   connectedPlatforms: Record<string, boolean>;
-  subscriptionTier: 'standard' | 'plus' | 'premium' | 'pro';
+  subscriptionTier: 'free' | 'plus' | 'premium' | 'pro';
   canEmbed: boolean;
   onUpgradeSubscription: () => void;
 }
@@ -80,7 +80,7 @@ const VenuePostsExternalTab: React.FC<VenuePostsExternalTabProps> = ({
       <div className="flex justify-end mb-4">
         <Button variant="default" size="sm" onClick={handleUpgradeClick}>
           <Plus className="h-4 w-4 mr-1" />
-          {subscriptionTier === 'standard' || subscriptionTier === 'plus' 
+          {subscriptionTier === 'free' || subscriptionTier === 'plus'
             ? 'Upgrade to Premium' 
             : 'Connect Platform'}
         </Button>

--- a/src/components/venue/tabs/VenuePostsTabsContent.tsx
+++ b/src/components/venue/tabs/VenuePostsTabsContent.tsx
@@ -11,7 +11,7 @@ interface VenuePostsTabsContentProps {
   venue: Location;
   viewMode: "list" | "grid";
   getPostComments: (postId: string) => Comment[];
-  subscriptionTier: 'standard' | 'plus' | 'premium' | 'pro';
+  subscriptionTier: 'free' | 'plus' | 'premium' | 'pro';
   canEmbed: boolean;
   connectedPlatforms: Record<string, boolean>;
   onUpgradeSubscription: () => void;

--- a/src/components/venue/tabs/VenuePostsVrnTab.tsx
+++ b/src/components/venue/tabs/VenuePostsVrnTab.tsx
@@ -10,7 +10,7 @@ interface VenuePostsVrnTabProps {
   venue: Location;
   viewMode: "list" | "grid";
   getComments: (postId: string) => Comment[];
-  subscriptionTier?: 'standard' | 'plus' | 'premium' | 'pro';
+  subscriptionTier?: 'free' | 'plus' | 'premium' | 'pro';
   onPostDeleted?: (postId: string) => void;
 }
 
@@ -20,7 +20,7 @@ const VenuePostsVrnTab: React.FC<VenuePostsVrnTabProps> = ({
   venue,
   viewMode,
   getComments,
-  subscriptionTier = 'standard',
+  subscriptionTier = 'free',
   onPostDeleted
 }) => {
   return (

--- a/src/hooks/useVenueConnections.ts
+++ b/src/hooks/useVenueConnections.ts
@@ -1,5 +1,6 @@
 
 import { useState, useEffect } from 'react';
+import { useUserSubscription } from '@/hooks/useUserSubscription';
 
 export const useVenueConnections = (venueId: string) => {
   // State for social media connections
@@ -14,8 +15,8 @@ export const useVenueConnections = (venueId: string) => {
     other: false
   });
   
-  // State to track subscription tier
-  const [subscriptionTier, setSubscriptionTier] = useState<'standard' | 'plus' | 'premium' | 'pro'>('standard');
+  // Access subscription data from the authoritative hook
+  const { tier, updateSubscriptionTier } = useUserSubscription();
   
   // Load saved platforms on component mount
   useEffect(() => {
@@ -23,7 +24,7 @@ export const useVenueConnections = (venueId: string) => {
     if (savedKeys) {
       try {
         const parsedKeys = JSON.parse(savedKeys);
-        
+
         // Set platforms as connected if they have API keys
         const connected: Record<string, boolean> = {};
         Object.keys(parsedKeys).forEach(key => {
@@ -34,31 +35,24 @@ export const useVenueConnections = (venueId: string) => {
         console.error('Error parsing saved API keys:', error);
       }
     }
-    
-    // Check for subscription tier in localStorage
-    const savedTier = localStorage.getItem('subscriptionTier');
-    if (savedTier) {
-      setSubscriptionTier(savedTier as 'standard' | 'plus' | 'premium' | 'pro');
-    }
   }, [venueId]);
   
   // Handle upgrading subscription
   const handleUpgradeSubscription = () => {
     // For demo purposes, cycle through subscription tiers
-    const tiers: Array<'standard' | 'plus' | 'premium' | 'pro'> = ['standard', 'plus', 'premium', 'pro'];
-    const currentIndex = tiers.indexOf(subscriptionTier);
+    const tiers: Array<'free' | 'plus' | 'premium' | 'pro'> = ['free', 'plus', 'premium', 'pro'];
+    const currentIndex = tiers.indexOf(tier);
     const nextTier = tiers[(currentIndex + 1) % tiers.length];
-    setSubscriptionTier(nextTier);
-    localStorage.setItem('subscriptionTier', nextTier);
+    updateSubscriptionTier(nextTier);
   };
   
   // Check if embedding is allowed (premium/pro tiers only)
-  const canEmbed = subscriptionTier === 'premium' || subscriptionTier === 'pro';
+  const canEmbed = tier === 'premium' || tier === 'pro';
   
   return {
     connectedPlatforms,
     setConnectedPlatforms,
-    subscriptionTier,
+    subscriptionTier: tier,
     handleUpgradeSubscription,
     canEmbed
   };


### PR DESCRIPTION
## Summary
- centralize subscription info by using `useUserSubscription` inside `useVenueConnections`
- drop local subscription tier storage
- update venue post tabs to use `free` tier names

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_685c8281cc0c832aa53f88713a45af4a