### PR TITLE
Use refs for map resize

### DIFF
--- a/src/components/LocationsNearby.tsx
+++ b/src/components/LocationsNearby.tsx
@@ -56,12 +56,10 @@ const LocationsNearby = () => {
   
   const toggleMapExpansion = () => {
     setIsMapExpanded(!isMapExpanded);
-    
+
     // Trigger map resize after state update
     setTimeout(() => {
-      if (window.resizeMap) {
-        window.resizeMap();
-      }
+      // Leaflet maps automatically handle container size changes
     }, 10);
   };
   

--- a/src/components/map/GoogleMap.tsx
+++ b/src/components/map/GoogleMap.tsx
@@ -1,5 +1,5 @@
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, forwardRef, useImperativeHandle } from "react";
 import { GoogleMap, useJsApiLoader, Marker, InfoWindow } from '@react-google-maps/api';
 import { Location } from "@/types";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -31,15 +31,19 @@ interface GoogleMapComponentProps {
   userAddressLocation?: [number, number] | null;
 }
 
-const GoogleMapComponent = ({ 
-  userLocation, 
-  locations, 
-  searchedCity, 
+export interface GoogleMapHandle {
+  resize: () => void;
+}
+
+const GoogleMapComponent = forwardRef<GoogleMapHandle, GoogleMapComponentProps>(({ 
+  userLocation,
+  locations,
+  searchedCity,
   mapStyle,
   onLocationSelect,
   showDistances = false,
   userAddressLocation = null
-}: GoogleMapComponentProps) => {
+}: GoogleMapComponentProps, ref) => {
   const { isLoaded, loadError } = useJsApiLoader({
     id: 'google-map-script',
     googleMapsApiKey: GOOGLE_MAPS_API_KEY
@@ -127,18 +131,9 @@ const GoogleMapComponent = ({
     }
   };
 
-  // Expose resize method to parent
-  useEffect(() => {
-    if (window) {
-      window.resizeMap = resizeMap;
-    }
-    
-    return () => {
-      if (window) {
-        delete window.resizeMap;
-      }
-    };
-  }, [map]);
+  useImperativeHandle(ref, () => ({
+    resize: resizeMap
+  }), [resizeMap]);
 
   if (loadError) {
     toast.error("Error loading maps");

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -1,8 +1,8 @@
 
-import React from "react";
+import React, { useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Compass } from "lucide-react";
-import GoogleMapComponent from "./google/GoogleMapComponent";
+import GoogleMapComponent, { GoogleMapHandle } from "./google/GoogleMapComponent";
 import LocationDetailsSidebar from "./LocationDetailsSidebar";
 import { Location } from "@/types";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -41,6 +41,7 @@ const MapContainer = ({
   showAllCities = true
 }: MapContainerProps) => {
   const isMobile = useIsMobile();
+  const mapRef = useRef<GoogleMapHandle>(null);
   
   if (loading) {
     return (
@@ -55,6 +56,7 @@ const MapContainer = ({
   return (
     <div className={`relative ${isExpanded ? "h-[85vh]" : isMobile ? "h-80" : "h-80"} rounded-lg overflow-hidden transition-all`} style={{ zIndex: 1 }}>
       <GoogleMapComponent
+        ref={mapRef}
         userLocation={userLocation}
         locations={locations}
         searchedCity={searchedCity}
@@ -95,7 +97,7 @@ const MapContainer = ({
           variant="outline" 
           size="sm" 
           className="absolute top-2 right-2 bg-background/80 backdrop-blur-sm" 
-          onClick={() => window.resizeMap && window.resizeMap()}
+          onClick={() => mapRef.current?.resize()}
         >
           Expand Map
         </Button>

--- a/src/components/map/MapboxMap.tsx
+++ b/src/components/map/MapboxMap.tsx
@@ -1,5 +1,5 @@
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, forwardRef, useImperativeHandle } from "react";
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { Location } from "@/types";
@@ -22,15 +22,19 @@ interface MapboxMapProps {
   userAddressLocation?: [number, number] | null;
 }
 
-const MapboxMap = ({ 
-  userLocation, 
-  locations, 
-  searchedCity, 
+export interface MapboxMapHandle {
+  resize: () => void;
+}
+
+const MapboxMap = forwardRef<MapboxMapHandle, MapboxMapProps>(({ 
+  userLocation,
+  locations,
+  searchedCity,
   mapStyle,
   onLocationSelect,
   showDistances = false,
   userAddressLocation = null
-}: MapboxMapProps) => {
+}: MapboxMapProps, ref) => {
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
   const markersRef = useRef<mapboxgl.Marker[]>([]);
@@ -299,18 +303,9 @@ const MapboxMap = ({
     }
   };
 
-  // Expose resize method to parent
-  useEffect(() => {
-    if (window && mapRef.current) {
-      window.resizeMap = resizeMap;
-    }
-    
-    return () => {
-      if (window) {
-        delete window.resizeMap;
-      }
-    };
-  }, [mapRef.current]);
+  useImperativeHandle(ref, () => ({
+    resize: resizeMap
+  }), [resizeMap]);
 
   return (
     <div ref={mapContainerRef} className="h-full w-full" />

--- a/src/components/map/google/EnhancedGoogleMapComponent.tsx
+++ b/src/components/map/google/EnhancedGoogleMapComponent.tsx
@@ -1,5 +1,5 @@
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, forwardRef, useImperativeHandle } from "react";
 import { GoogleMap, Marker, InfoWindow } from '@react-google-maps/api';
 import { Location } from "@/types";
 import { getMapOptions } from './MapStyles';
@@ -31,11 +31,15 @@ interface EnhancedGoogleMapComponentProps {
   onMapReady?: (map: google.maps.Map) => void;
 }
 
-const EnhancedGoogleMapComponent = ({ 
-  userLocation, 
-  locations, 
+export interface GoogleMapHandle {
+  resize: () => void;
+}
+
+const EnhancedGoogleMapComponent = forwardRef<GoogleMapHandle, EnhancedGoogleMapComponentProps>(({
+  userLocation,
+  locations,
   realPlaces = [],
-  searchedCity, 
+  searchedCity,
   mapStyle,
   onLocationSelect,
   onPlaceSelect,
@@ -46,7 +50,7 @@ const EnhancedGoogleMapComponent = ({
   mapCenter,
   mapZoom,
   onMapReady
-}: EnhancedGoogleMapComponentProps) => {
+}: EnhancedGoogleMapComponentProps, ref) => {
   const [selectedRealPlace, setSelectedRealPlace] = useState<Location | null>(selectedPlace);
   const [map, setMap] = useState<google.maps.Map | null>(null);
 
@@ -59,14 +63,19 @@ const EnhancedGoogleMapComponent = ({
     setSelectedMarker,
     onLoad: defaultOnLoad,
     onUnmount,
-    handleMarkerClick
+    handleMarkerClick,
+    resizeMap
   } = useGoogleMap(
-    userLocation, 
-    userAddressLocation, 
-    locations, 
-    searchedCity, 
+    userLocation,
+    userAddressLocation,
+    locations,
+    searchedCity,
     selectedLocation
   );
+
+  useImperativeHandle(ref, () => ({
+    resize: resizeMap
+  }), [resizeMap]);
 
   // Use provided center/zoom or fall back to defaults
   const effectiveCenter = mapCenter || defaultMapCenter;

--- a/src/components/map/google/GoogleMap.tsx
+++ b/src/components/map/google/GoogleMap.tsx
@@ -1,5 +1,5 @@
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, forwardRef, useImperativeHandle } from "react";
 import { GoogleMap } from '@react-google-maps/api';
 import { Location } from "@/types";
 import GoogleMapMarkers from './GoogleMapMarkers';
@@ -24,17 +24,21 @@ interface GoogleMapComponentProps {
   showAllCities?: boolean;
 }
 
-const GoogleMapComponent = ({ 
-  userLocation, 
-  locations, 
-  searchedCity, 
+export interface GoogleMapHandle {
+  resize: () => void;
+}
+
+const GoogleMapComponent = forwardRef<GoogleMapHandle, GoogleMapComponentProps>(({
+  userLocation,
+  locations,
+  searchedCity,
   mapStyle,
   onLocationSelect,
   showDistances = false,
   userAddressLocation = null,
   selectedLocation = null,
   showAllCities = true
-}: GoogleMapComponentProps) => {
+}: GoogleMapComponentProps, ref) => {
   const {
     isLoaded,
     loadError,
@@ -44,14 +48,19 @@ const GoogleMapComponent = ({
     setSelectedMarker,
     onLoad,
     onUnmount,
-    handleMarkerClick
+    handleMarkerClick,
+    resizeMap
   } = useGoogleMap(
-    userLocation, 
-    userAddressLocation, 
-    locations, 
-    searchedCity, 
+    userLocation,
+    userAddressLocation,
+    locations,
+    searchedCity,
     selectedLocation
   );
+
+  useImperativeHandle(ref, () => ({
+    resize: resizeMap
+  }), [resizeMap]);
 
   // Main handler for marker clicks
   const handleLocationSelect = (location: Location) => {

--- a/src/components/map/google/GoogleMapComponent.tsx
+++ b/src/components/map/google/GoogleMapComponent.tsx
@@ -1,5 +1,5 @@
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, forwardRef, useImperativeHandle } from "react";
 import { GoogleMap } from '@react-google-maps/api';
 import { Location } from "@/types";
 import GoogleMapMarkers from './GoogleMapMarkers';
@@ -24,17 +24,21 @@ interface GoogleMapComponentProps {
   showAllCities?: boolean;
 }
 
-const GoogleMapComponent = ({ 
-  userLocation, 
-  locations, 
-  searchedCity, 
+export interface GoogleMapHandle {
+  resize: () => void;
+}
+
+const GoogleMapComponent = forwardRef<GoogleMapHandle, GoogleMapComponentProps>(({ 
+  userLocation,
+  locations,
+  searchedCity,
   mapStyle,
   onLocationSelect,
   showDistances = false,
   userAddressLocation = null,
   selectedLocation = null,
   showAllCities = true
-}: GoogleMapComponentProps) => {
+}: GoogleMapComponentProps, ref) => {
   const {
     isLoaded,
     loadError,
@@ -44,14 +48,19 @@ const GoogleMapComponent = ({
     setSelectedMarker,
     onLoad,
     onUnmount,
-    handleMarkerClick
+    handleMarkerClick,
+    resizeMap
   } = useGoogleMap(
-    userLocation, 
-    userAddressLocation, 
-    locations, 
-    searchedCity, 
+    userLocation,
+    userAddressLocation,
+    locations,
+    searchedCity,
     selectedLocation
   );
+
+  useImperativeHandle(ref, () => ({
+    resize: resizeMap
+  }), [resizeMap]);
 
   // Main handler for marker clicks
   const handleLocationSelect = (location: Location) => {

--- a/src/components/map/google/useGoogleMap.tsx
+++ b/src/components/map/google/useGoogleMap.tsx
@@ -73,18 +73,6 @@ export const useGoogleMap = (
     }
   }, [map, userLocation]);
 
-  // Expose resize method to window
-  useEffect(() => {
-    if (window) {
-      window.resizeMap = resizeMap;
-    }
-    
-    return () => {
-      if (window) {
-        delete window.resizeMap;
-      }
-    };
-  }, [resizeMap]);
 
   // Handle marker click
   const handleMarkerClick = useCallback((location: Location) => {
@@ -106,7 +94,8 @@ export const useGoogleMap = (
     setSelectedMarker,
     onLoad,
     onUnmount,
-    handleMarkerClick
+    handleMarkerClick,
+    resizeMap
   };
 };
 

--- a/src/components/map/mapbox/MapboxMap.tsx
+++ b/src/components/map/mapbox/MapboxMap.tsx
@@ -1,5 +1,5 @@
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, forwardRef, useImperativeHandle } from "react";
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { Location } from "@/types";
@@ -21,15 +21,19 @@ interface MapboxMapProps {
   userAddressLocation?: [number, number] | null;
 }
 
-const MapboxMap = ({ 
-  userLocation, 
-  locations, 
-  searchedCity, 
+export interface MapboxMapHandle {
+  resize: () => void;
+}
+
+const MapboxMap = forwardRef<MapboxMapHandle, MapboxMapProps>(({ 
+  userLocation,
+  locations,
+  searchedCity,
   mapStyle,
   onLocationSelect,
   showDistances = false,
   userAddressLocation = null
-}: MapboxMapProps) => {
+}: MapboxMapProps, ref) => {
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
   const markersRef = useRef<mapboxgl.Marker[]>([]);
@@ -111,18 +115,9 @@ const MapboxMap = ({
     }
   };
 
-  // Expose resize method to parent
-  useEffect(() => {
-    if (window && mapRef.current) {
-      window.resizeMap = resizeMap;
-    }
-    
-    return () => {
-      if (window) {
-        delete window.resizeMap;
-      }
-    };
-  }, [mapRef.current]);
+  useImperativeHandle(ref, () => ({
+    resize: resizeMap
+  }), [resizeMap]);
   
   // Add markers to map
   const addMarkersToMap = () => {

--- a/src/pages/VenueProfile.tsx
+++ b/src/pages/VenueProfile.tsx
@@ -1,5 +1,5 @@
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { useParams } from "react-router-dom";
 import { Minimize } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -7,7 +7,7 @@ import { mockLocations, mockPosts, mockComments } from "@/mock/data";
 import CameraButton from "@/components/CameraButton";
 import Header from "@/components/Header";
 import { Comment, Post, Location as VenueLocation } from "@/types";
-import GoogleMapComponent from "@/components/map/google/GoogleMap";
+import GoogleMapComponent, { GoogleMapHandle } from "@/components/map/google/GoogleMap";
 import { generateBusinessHours } from "@/utils/businessHoursUtils";
 import { 
   isPostFromDayOfWeek, 
@@ -38,6 +38,7 @@ const VenueProfile = () => {
   const [viewMode, setViewMode] = useState<"list" | "grid">("list");
   const [isMapExpanded, setIsMapExpanded] = useState(false);
   const [selectedDays, setSelectedDays] = useState<number[]>([]);
+  const mapRef = useRef<GoogleMapHandle>(null);
   const [isVenueOwner, setIsVenueOwner] = useState(false);
   const [subscriptionTier, setSubscriptionTier] = useState<'standard' | 'plus' | 'premium' | 'pro'>('standard');
   
@@ -105,9 +106,7 @@ const VenueProfile = () => {
     setIsMapExpanded(!isMapExpanded);
     
     setTimeout(() => {
-      if (window.resizeMap) {
-        window.resizeMap();
-      }
+      mapRef.current?.resize();
     }, 10);
   };
   
@@ -155,6 +154,7 @@ const VenueProfile = () => {
           </div>
           <div className="h-[85vh] rounded-lg overflow-hidden">
             <GoogleMapComponent
+              ref={mapRef}
               userLocation={null}
               locations={[venue]}
               searchedCity={venue.city}

--- a/src/types/custom.d.ts
+++ b/src/types/custom.d.ts
@@ -1,5 +1,4 @@
 
 interface Window {
-  resizeMap?: () => void;
   matchMedia: (query: string) => MediaQueryList;
 }

--- a/src/types/leaflet.d.ts
+++ b/src/types/leaflet.d.ts
@@ -23,7 +23,5 @@ declare module 'react-leaflet' {
 }
 
 declare global {
-  interface Window {
-    resizeMap?: () => void;
-  }
+  interface Window {}
 }


### PR DESCRIPTION
## Summary
- expose `resize` methods via `useImperativeHandle` in Google and Mapbox maps
- call the resize functions through refs instead of the `window.resizeMap` global
- remove `resizeMap` from type definitions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c8284c5d8832aabd7a2613b10ebd5