### PR TITLE
Remove unused sidebar state from store

### DIFF
--- a/src/providers/StoreProvider.tsx
+++ b/src/providers/StoreProvider.tsx
@@ -56,7 +56,6 @@ export const useStoreActions = () => {
     
     // UI actions
     setLoading: store.setLoading,
-    setSidebarOpen: store.setSidebarOpen,
     setTheme: store.setTheme,
     addNotification: store.addNotification,
     removeNotification: store.removeNotification,

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -27,7 +27,6 @@ export const useAppStore = create<AppStore>()(
           followedVenues: state.followedVenues,
           ui: {
             currentTheme: state.ui.currentTheme,
-            isSidebarOpen: state.ui.isSidebarOpen,
           },
           chatState: {
             chatMode: state.chatState.chatMode,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -32,7 +32,6 @@ export interface Location {
 
 export interface UIState {
   isLoading: boolean;
-  isSidebarOpen: boolean;
   currentTheme: 'light' | 'dark' | 'system';
   notifications: Notification[];
 }
@@ -104,7 +103,6 @@ export interface ChatSlice {
 export interface UISlice {
   ui: UIState;
   setLoading: (loading: boolean) => void;
-  setSidebarOpen: (open: boolean) => void;
   setTheme: (theme: 'light' | 'dark' | 'system') => void;
   addNotification: (notification: Omit<Notification, 'id' | 'timestamp'>) => void;
   removeNotification: (id: string) => void;

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -11,7 +11,6 @@ export const createUISlice: StateCreator<
 > = (set) => ({
   ui: {
     isLoading: false,
-    isSidebarOpen: false,
     currentTheme: 'system',
     notifications: [],
   },
@@ -22,11 +21,6 @@ export const createUISlice: StateCreator<
     });
   },
   
-  setSidebarOpen: (open: boolean) => {
-    set((state) => {
-      state.ui.isSidebarOpen = open;
-    });
-  },
   
   setTheme: (theme: 'light' | 'dark' | 'system') => {
     set((state) => {
@@ -65,10 +59,9 @@ export const createUISlice: StateCreator<
 
 // Export individual store hook
 export const useUIStore = () => {
-  const { 
+  const {
     ui,
     setLoading,
-    setSidebarOpen,
     setTheme,
     addNotification,
     removeNotification,
@@ -78,7 +71,6 @@ export const useUIStore = () => {
   return { 
     ui,
     setLoading,
-    setSidebarOpen,
     setTheme,
     addNotification,
     removeNotification,


### PR DESCRIPTION
## Summary
- drop `isSidebarOpen` and related actions from store
- remove unused sidebar actions in `StoreProvider`

## Testing
- `npm run lint` *(fails: cannot fix extensive existing lint errors)*
- `npm run build:dev`

------
https://chatgpt.com/codex/tasks/task_e_685c82830308832aabcd16dcf29b129d