### PR TITLE
Integrate Supabase data layer with mock fallback & auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# Vibe Right Now — environment configuration
+# Copy to `.env.local` and fill in. Everything here is OPTIONAL for the demo:
+# with no keys set, the app falls back to mock data/behaviour (see VITE_USE_MOCK_FALLBACK).
+
+# --- Data layer -------------------------------------------------------------
+# When "true" (default), the data layer falls back to src/mock/* whenever a Supabase
+# query errors or returns nothing. Set "false" to force real-data-only mode (useful for
+# verifying that persistence actually works end-to-end against a seeded, authed database).
+VITE_USE_MOCK_FALLBACK=true
+
+# --- Client-side keys (read via import.meta.env) ----------------------------
+# Google Maps JS API key for the Explore map.
+VITE_GOOGLE_MAPS_API_KEY=
+# Optional direct LLM keys; prefer routing through Supabase edge functions instead.
+VITE_OPENAI_API_KEY=
+VITE_OPENROUTER_API_KEY=
+
+# --- Supabase edge function secrets -----------------------------------------
+# These are NOT read by the client; set them on the Supabase project
+# (Project Settings -> Edge Functions -> Secrets) so the edge functions can call out.
+#   GEMINI_API_KEY / GOOGLE_VERTEX_*   -> vertex-ai, gemini-ai
+#   OPENROUTER_API_KEY                 -> openai-chat
+#   PERPLEXITY_API_KEY                 -> perplexity-search
+#   GOOGLE_PLACES_API_KEY              -> google-places
+#   YELP_API_KEY                       -> yelp-fusion
+#   TICKETMASTER_API_KEY               -> ticketmaster
+#   ELEVENLABS_API_KEY                 -> eleven-labs-tts
+#   DEEPGRAM_API_KEY                   -> speech-to-text fallback
+#   SQUARE_ACCESS_TOKEN                -> square-ai

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 .env
+
+# Claude Code local state and agent worktrees
+.claude/

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,7 +170,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1676,7 +1675,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -1694,7 +1692,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1707,7 +1704,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1720,14 +1716,12 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -1745,7 +1739,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -1761,7 +1754,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -1800,7 +1792,6 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
       "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -1815,7 +1806,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1825,7 +1815,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1835,14 +1824,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1903,7 +1890,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1917,7 +1903,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1927,7 +1912,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1950,7 +1934,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -4210,14 +4193,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4228,7 +4211,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -4632,14 +4615,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4653,7 +4634,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -4770,7 +4750,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4813,7 +4792,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4878,7 +4856,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4932,7 +4909,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -4957,7 +4933,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5102,7 +5077,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -5370,7 +5344,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/diff-match-patch": {
@@ -5383,7 +5356,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-helpers": {
@@ -5406,7 +5378,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -5780,7 +5751,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5797,7 +5767,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5824,7 +5793,6 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -5856,7 +5824,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -5913,7 +5880,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -5930,7 +5896,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -6029,7 +5994,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6044,7 +6008,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6093,7 +6056,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -6235,7 +6197,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6364,7 +6325,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -6377,7 +6337,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -6408,7 +6367,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6427,7 +6385,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -6440,7 +6397,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -6483,7 +6439,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -6499,7 +6454,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -6647,7 +6601,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -6660,7 +6613,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -6841,7 +6793,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -6851,7 +6802,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -6951,7 +6901,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -7050,7 +6999,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7079,7 +7027,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -7279,7 +7226,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -7318,7 +7264,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -7369,14 +7314,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -7389,7 +7332,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7399,7 +7341,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -7429,7 +7370,6 @@
       "version": "8.5.5",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.5.tgz",
       "integrity": "sha512-d/jtm+rdNT8tpXuHY5MMtcbJFBkhXE6593XVR9UoGCH8jSFGci7jGvMGH5RYd5PBJW+00NZQt6gf7CbagJCrhg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7458,7 +7398,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -7476,7 +7415,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
@@ -7496,7 +7434,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
       "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7532,7 +7469,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7558,7 +7494,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -7586,7 +7521,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/potpack": {
@@ -7688,7 +7622,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7932,7 +7865,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -7956,7 +7888,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -8001,7 +7932,6 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.0",
@@ -8041,7 +7971,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -8140,7 +8069,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8357,7 +8285,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8412,7 +8339,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8440,7 +8366,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8466,7 +8391,6 @@
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -8489,7 +8413,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -8499,7 +8422,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -8509,7 +8431,6 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -8530,7 +8451,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -8546,7 +8466,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -8578,7 +8497,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8614,7 +8532,6 @@
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -8661,7 +8578,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8701,7 +8617,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -8711,7 +8626,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -8757,7 +8671,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -8798,7 +8711,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -9604,7 +9516,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -9680,7 +9591,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
       "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { Suspense, lazy, useEffect } from "react";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import VernonNext from '@/components/VernonNext';
-import { Auth0Provider } from "./auth/Auth0Provider";
+import { SupabaseAuthProvider } from "./auth/SupabaseAuthProvider";
 import { MobileProvider } from "@/providers/MobileProvider";
 
 // Lazy-loaded components
@@ -39,7 +39,7 @@ function App() {
   }, []);
 
   return (
-    <Auth0Provider>
+    <SupabaseAuthProvider>
       <MobileProvider>
         <ThemeProvider defaultTheme="light" storageKey="vibe-ui-theme">
           <BrowserRouter>
@@ -72,7 +72,7 @@ function App() {
         </BrowserRouter>
         </ThemeProvider>
       </MobileProvider>
-    </Auth0Provider>
+    </SupabaseAuthProvider>
   );
 }
 

--- a/src/auth/SupabaseAuthProvider.tsx
+++ b/src/auth/SupabaseAuthProvider.tsx
@@ -1,0 +1,146 @@
+import React, { createContext, useCallback, useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import type { Session, User as SupabaseUser } from "@supabase/supabase-js";
+import { supabase } from "@/integrations/supabase/client";
+import { profilesRepo } from "@/services/data";
+import { useUserStore, mapProfileToStoreUser } from "@/store/userStore";
+
+export interface SupabaseAuthContextValue {
+  session: Session | null;
+  user: SupabaseUser | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  signIn: (email: string, password: string) => Promise<void>;
+  signUp: (email: string, password: string) => Promise<void>;
+  signInWithGoogle: () => Promise<void>;
+  signInWithMagicLink: (email: string) => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+export const SupabaseAuthContext = createContext<SupabaseAuthContextValue | null>(null);
+
+export const SupabaseAuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const { login, logout } = useUserStore();
+
+  // Load the profile for an authenticated user and push it into the Zustand store.
+  const syncProfileToStore = useCallback(
+    async (supaUser: SupabaseUser | null) => {
+      if (!supaUser) {
+        logout();
+        return;
+      }
+      try {
+        const profile = await profilesRepo.getById(supaUser.id);
+        if (profile) {
+          login(mapProfileToStoreUser(profile, supaUser.email ?? undefined));
+        } else {
+          // No profile row yet (trigger lag) — seed store with minimal data from auth user.
+          login({
+            id: supaUser.id,
+            name:
+              (supaUser.user_metadata?.name as string) ||
+              supaUser.email?.split("@")[0] ||
+              "",
+            email: supaUser.email ?? "",
+            avatar: supaUser.user_metadata?.avatar_url as string | undefined,
+            subscription: "free",
+            points: 0,
+          });
+        }
+      } catch (err) {
+        console.warn("[auth] failed to sync profile to store:", err);
+      }
+    },
+    [login, logout],
+  );
+
+  useEffect(() => {
+    let mounted = true;
+
+    // 1. Subscribe to auth state changes first so nothing is missed.
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, newSession) => {
+      if (!mounted) return;
+      setSession(newSession);
+      // Defer store sync to avoid running async work directly inside the callback.
+      setTimeout(() => syncProfileToStore(newSession?.user ?? null), 0);
+    });
+
+    // 2. Then hydrate the existing session.
+    supabase.auth
+      .getSession()
+      .then(({ data }) => {
+        if (!mounted) return;
+        setSession(data.session);
+        return syncProfileToStore(data.session?.user ?? null);
+      })
+      .finally(() => {
+        if (mounted) setIsLoading(false);
+      });
+
+    return () => {
+      mounted = false;
+      subscription.unsubscribe();
+    };
+  }, [syncProfileToStore]);
+
+  const signIn = useCallback(async (email: string, password: string) => {
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) throw error;
+  }, []);
+
+  const signUp = useCallback(async (email: string, password: string) => {
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { emailRedirectTo: window.location.origin },
+    });
+    if (error) throw error;
+  }, []);
+
+  const signInWithGoogle = useCallback(async () => {
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: { redirectTo: window.location.origin },
+    });
+    if (error) throw error;
+  }, []);
+
+  const signInWithMagicLink = useCallback(async (email: string) => {
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: window.location.origin },
+    });
+    if (error) throw error;
+  }, []);
+
+  const signOut = useCallback(async () => {
+    const { error } = await supabase.auth.signOut();
+    if (error) throw error;
+    logout();
+  }, [logout]);
+
+  const value = useMemo<SupabaseAuthContextValue>(
+    () => ({
+      session,
+      user: session?.user ?? null,
+      isAuthenticated: !!session?.user,
+      isLoading,
+      signIn,
+      signUp,
+      signInWithGoogle,
+      signInWithMagicLink,
+      signOut,
+    }),
+    [session, isLoading, signIn, signUp, signInWithGoogle, signInWithMagicLink, signOut],
+  );
+
+  return (
+    <SupabaseAuthContext.Provider value={value}>{children}</SupabaseAuthContext.Provider>
+  );
+};
+
+export default SupabaseAuthProvider;

--- a/src/components/AuthDialog.tsx
+++ b/src/components/AuthDialog.tsx
@@ -6,8 +6,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
-import { Mail, Github, AlertCircle, Fingerprint, Lock } from "lucide-react";
-import { useAuth0Auth } from "@/hooks/useAuth0Auth";
+import { Mail, AlertCircle, Wand2 } from "lucide-react";
+import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 
 interface AuthDialogProps {
   open: boolean;
@@ -21,12 +21,15 @@ export function AuthDialog({ open, onOpenChange, mode, onModeChange }: AuthDialo
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const { toast } = useToast();
-  const { login, googleLogin, isLoading } = useAuth0Auth();
+  const { signIn, signUp, signInWithGoogle, signInWithMagicLink, isLoading } = useSupabaseAuth();
+  const [submitting, setSubmitting] = useState(false);
+  const busy = isLoading || submitting;
 
   const handleEmailAuth = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     try {
+      setSubmitting(true);
       // Basic validation
       if (!email.trim() || !password) {
         throw new Error("Email and password are required");
@@ -35,9 +38,18 @@ export function AuthDialog({ open, onOpenChange, mode, onModeChange }: AuthDialo
       if (mode === 'signup' && password !== confirmPassword) {
         throw new Error("Passwords do not match");
       }
-      
-      await login();
-      
+
+      if (mode === 'signup') {
+        await signUp(email.trim(), password);
+        toast({
+          title: "Check your inbox",
+          description: "We sent you a confirmation link to finish creating your account.",
+        });
+      } else {
+        await signIn(email.trim(), password);
+        toast({ title: "Welcome back!", description: "You're now signed in." });
+        onOpenChange(false);
+      }
     } catch (error) {
       toast({
         variant: "destructive",
@@ -49,30 +61,46 @@ export function AuthDialog({ open, onOpenChange, mode, onModeChange }: AuthDialo
           </Button>
         ),
       });
+    } finally {
+      setSubmitting(false);
     }
   };
 
   const handleGoogleAuth = async () => {
     try {
-      await googleLogin();
+      setSubmitting(true);
+      await signInWithGoogle();
+      // Redirect happens; dialog will close on return.
     } catch (error) {
       toast({
         variant: "destructive",
         title: "Google authentication error",
         description: error instanceof Error ? error.message : "Something went wrong with Google sign-in",
       });
+    } finally {
+      setSubmitting(false);
     }
   };
 
-  const handlePasskeyAuth = async () => {
+  const handleMagicLink = async () => {
     try {
-      await login();
+      setSubmitting(true);
+      if (!email.trim()) {
+        throw new Error("Enter your email to receive a magic link");
+      }
+      await signInWithMagicLink(email.trim());
+      toast({
+        title: "Magic link sent",
+        description: "Check your email for a link to sign in.",
+      });
     } catch (error) {
       toast({
         variant: "destructive",
-        title: "Passkey authentication error",
-        description: error instanceof Error ? error.message : "Something went wrong with passkey sign-in",
+        title: "Magic link error",
+        description: error instanceof Error ? error.message : "Could not send the magic link",
       });
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -119,11 +147,11 @@ export function AuthDialog({ open, onOpenChange, mode, onModeChange }: AuthDialo
                   required
                 />
               </div>
-              <Button type="submit" className="w-full" disabled={isLoading}>
-                {isLoading ? "Signing in..." : "Sign In with Email"}
+              <Button type="submit" className="w-full" disabled={busy}>
+                {busy ? "Signing in..." : "Sign In with Email"}
               </Button>
             </form>
-            
+
             <div className="relative">
               <div className="absolute inset-0 flex items-center">
                 <span className="w-full border-t" />
@@ -132,29 +160,29 @@ export function AuthDialog({ open, onOpenChange, mode, onModeChange }: AuthDialo
                 <span className="bg-background px-2 text-muted-foreground">Or continue with</span>
               </div>
             </div>
-            
+
             <div className="flex flex-col gap-2">
-              <Button 
-                variant="outline" 
-                className="w-full" 
+              <Button
+                variant="outline"
+                className="w-full"
                 onClick={handleGoogleAuth}
-                disabled={isLoading}
+                disabled={busy}
                 type="button"
               >
                 <Mail className="mr-2 h-4 w-4" /> Google
               </Button>
-              <Button 
-                variant="outline" 
-                className="w-full" 
-                onClick={handlePasskeyAuth}
-                disabled={isLoading}
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={handleMagicLink}
+                disabled={busy}
                 type="button"
               >
-                <Fingerprint className="mr-2 h-4 w-4" /> Passkey
+                <Wand2 className="mr-2 h-4 w-4" /> Email me a magic link
               </Button>
             </div>
           </TabsContent>
-          
+
           <TabsContent value="signup" className="space-y-4">
             <form onSubmit={handleEmailAuth} className="space-y-4">
               <div className="space-y-2">
@@ -188,11 +216,11 @@ export function AuthDialog({ open, onOpenChange, mode, onModeChange }: AuthDialo
                   required
                 />
               </div>
-              <Button type="submit" className="w-full" disabled={isLoading}>
-                {isLoading ? "Creating account..." : "Sign Up with Email"}
+              <Button type="submit" className="w-full" disabled={busy}>
+                {busy ? "Creating account..." : "Sign Up with Email"}
               </Button>
             </form>
-            
+
             <div className="relative">
               <div className="absolute inset-0 flex items-center">
                 <span className="w-full border-t" />
@@ -201,25 +229,25 @@ export function AuthDialog({ open, onOpenChange, mode, onModeChange }: AuthDialo
                 <span className="bg-background px-2 text-muted-foreground">Or continue with</span>
               </div>
             </div>
-            
+
             <div className="flex flex-col gap-2">
-              <Button 
-                variant="outline" 
-                className="w-full" 
+              <Button
+                variant="outline"
+                className="w-full"
                 onClick={handleGoogleAuth}
-                disabled={isLoading}
+                disabled={busy}
                 type="button"
               >
                 <Mail className="mr-2 h-4 w-4" /> Google
               </Button>
-              <Button 
-                variant="outline" 
-                className="w-full" 
-                onClick={handlePasskeyAuth}
-                disabled={isLoading}
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={handleMagicLink}
+                disabled={busy}
                 type="button"
               >
-                <Fingerprint className="mr-2 h-4 w-4" /> Passkey
+                <Wand2 className="mr-2 h-4 w-4" /> Email me a magic link
               </Button>
             </div>
           </TabsContent>

--- a/src/components/CameraButton.tsx
+++ b/src/components/CameraButton.tsx
@@ -1,6 +1,7 @@
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useToast } from "@/hooks/use-toast";
+import { toast as sonnerToast } from "sonner";
 import {
   Dialog,
   DialogContent,
@@ -11,6 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { ImagePlus, Loader2 } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import SmartCameraButton from "./mobile/SmartCameraButton";
 import { useCameraAccess } from "@/hooks/useCameraAccess";
@@ -18,6 +20,7 @@ import CameraTab from "./camera/CameraTab";
 import GalleryTab from "./camera/GalleryTab";
 import LocationInput from "./camera/LocationInput";
 import PinRewardsSection from "./camera/PinRewardsSection";
+import { createPost, NotSignedInError } from "@/services/posts/createPost";
 
 const CameraButton = () => {
   const { toast } = useToast();
@@ -29,6 +32,10 @@ const CameraButton = () => {
   const [isCheckingLocation, setIsCheckingLocation] = useState(false);
   const [locationVerified, setLocationVerified] = useState(false);
   const [capturedPhoto, setCapturedPhoto] = useState<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [caption, setCaption] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleCameraClick = () => {
     setIsDialogOpen(true);
@@ -39,16 +46,15 @@ const CameraButton = () => {
       const photo = await takePhoto();
       if (photo?.webPath) {
         setCapturedPhoto(photo.webPath);
+        setSelectedFile(null);
         toast({
           title: "Photo Captured",
           description: "Your photo has been captured successfully!",
         });
       }
     } else {
-      toast({
-        title: "Camera Not Available",
-        description: "Camera access is only available on mobile devices. Please use the gallery option.",
-      });
+      // On web, fall back to the file picker.
+      fileInputRef.current?.click();
     }
   };
 
@@ -57,48 +63,78 @@ const CameraButton = () => {
       const photo = await selectFromGallery();
       if (photo?.webPath) {
         setCapturedPhoto(photo.webPath);
+        setSelectedFile(null);
         toast({
           title: "Photo Selected",
           description: "Your photo has been selected from gallery!",
         });
       }
     } else {
-      toast({
-        title: "Gallery Not Available",
-        description: "Gallery access is only available on mobile devices.",
-      });
+      fileInputRef.current?.click();
     }
   };
 
-  const handleSubmit = () => {
-    setIsDialogOpen(false);
-    
-    const pointsEarned = availableToPin ? 3 : 2;
-    
-    toast({
-      title: "Vibe Posted",
-      description: availableToPin 
-        ? `Your vibe has been posted and is available for venues to pin for longer than 90 days! (${pointsEarned}x points)` 
-        : `Your vibe has been posted and will be visible for 1 week! (${pointsEarned}x points)`,
-    });
-    
-    // Reset form
+  const handleWebFileSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setSelectedFile(file);
+    setCapturedPhoto(URL.createObjectURL(file));
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const resetForm = () => {
+    if (capturedPhoto && selectedFile) URL.revokeObjectURL(capturedPhoto);
     setCapturedPhoto(null);
+    setSelectedFile(null);
+    setCaption("");
     setLocation("");
     setLocationVerified(false);
     setAvailableToPin(false);
   };
 
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await createPost({
+        content: caption.trim(),
+        files: selectedFile ? [selectedFile] : [],
+        // Captured (native) photos are object/web URLs we can attach directly.
+        mediaUrls: !selectedFile && capturedPhoto ? [capturedPhoto] : [],
+        location: locationVerified && location.trim() ? { name: location.trim() } : undefined,
+      });
+
+      const pointsEarned = availableToPin ? 3 : 2;
+      toast({
+        title: "Vibe Posted",
+        description: availableToPin
+          ? `Your vibe has been posted and is available for venues to pin for longer than 90 days! (${pointsEarned}x points)`
+          : `Your vibe has been posted and will be visible for 1 week! (${pointsEarned}x points)`,
+      });
+
+      resetForm();
+      setIsDialogOpen(false);
+    } catch (error) {
+      if (error instanceof NotSignedInError) {
+        sonnerToast("Sign in to post a vibe");
+      } else {
+        console.error("Vibe post failed", error);
+        sonnerToast.error("Couldn't post your vibe. Please try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   const verifyLocation = () => {
     if (!location.trim()) return;
-    
+
     setIsCheckingLocation(true);
-    
+
     // Simulate location verification
     setTimeout(() => {
       setIsCheckingLocation(false);
       setLocationVerified(true);
-      
+
       toast({
         title: "Location Verified",
         description: "You're near this location and can post a vibe!",
@@ -115,6 +151,14 @@ const CameraButton = () => {
     <>
       <SmartCameraButton onClick={handleCameraClick} />
 
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*,video/*"
+        className="hidden"
+        onChange={handleWebFileSelected}
+      />
+
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogContent className="glass-effect max-w-md">
           <DialogHeader>
@@ -123,20 +167,20 @@ const CameraButton = () => {
               Share the vibe at your current location. Your post will be visible for 1 week by default.
             </DialogDescription>
           </DialogHeader>
-          
+
           <Tabs defaultValue="camera" value={activeTab} onValueChange={setActiveTab}>
             <TabsList className="grid grid-cols-2 mb-4">
               <TabsTrigger value="camera">Camera</TabsTrigger>
               <TabsTrigger value="gallery">Gallery</TabsTrigger>
             </TabsList>
-            
+
             <CameraTab
               capturedPhoto={capturedPhoto}
               isCapacitorNative={isCapacitorNative}
               isLoading={isLoading}
               onCameraCapture={handleCameraCapture}
             />
-            
+
             <GalleryTab
               capturedPhoto={capturedPhoto}
               isCapacitorNative={isCapacitorNative}
@@ -144,8 +188,20 @@ const CameraButton = () => {
               onGallerySelect={handleGallerySelect}
             />
           </Tabs>
-          
+
           <div className="space-y-4">
+            {!isCapacitorNative && (
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <ImagePlus className="h-4 w-4 mr-2" />
+                {capturedPhoto ? "Change photo" : "Choose a photo"}
+              </Button>
+            )}
+
             <LocationInput
               location={location}
               isCheckingLocation={isCheckingLocation}
@@ -153,34 +209,44 @@ const CameraButton = () => {
               onLocationChange={handleLocationChange}
               onVerifyLocation={verifyLocation}
             />
-            
-            <Input 
+
+            <Input
               placeholder="Add a caption (optional)"
               className="bg-background/50"
+              value={caption}
+              onChange={(e) => setCaption(e.target.value)}
             />
-            
+
             <PinRewardsSection
               availableToPin={availableToPin}
               onAvailableToPinChange={setAvailableToPin}
             />
           </div>
-          
+
           <DialogFooter className="flex-col sm:flex-row gap-2">
-            <Button 
-              type="button" 
-              variant="outline" 
+            <Button
+              type="button"
+              variant="outline"
               onClick={() => setIsDialogOpen(false)}
               className="sm:flex-1"
+              disabled={submitting}
             >
               Cancel
             </Button>
-            <Button 
-              type="button" 
-              className="bg-gradient-to-r from-primary to-secondary sm:flex-1" 
+            <Button
+              type="button"
+              className="bg-gradient-to-r from-primary to-secondary sm:flex-1"
               onClick={handleSubmit}
-              disabled={!locationVerified}
+              disabled={!locationVerified || submitting}
             >
-              Post Right Now
+              {submitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Posting...
+                </>
+              ) : (
+                "Post Right Now"
+              )}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,9 +12,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger 
 } from "@/components/ui/dropdown-menu";
-import { User, Bookmark, MapPin, Award, UserCircle, LogIn, Settings, BarChart, Headphones, Megaphone, MessageSquare } from "lucide-react";
+import { User, Bookmark, MapPin, Award, UserCircle, LogIn, LogOut, Settings, BarChart, Headphones, Megaphone, MessageSquare } from "lucide-react";
 import { useEffect, useState } from "react";
 import { AuthDialog } from "@/components/AuthDialog";
+import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
+import { toast } from "sonner";
 import VernonConciergeDialog from "./VernonConcierge/VernonConciergeDialog";
 
 // Full list of rotating V-words for the branding
@@ -61,8 +63,19 @@ const Header = () => {
     return () => clearInterval(interval);
   }, []);
 
+  const { isAuthenticated, signOut } = useSupabaseAuth();
+
   const handleOpenAuth = () => {
     setShowAuthDialog(true);
+  };
+
+  const handleSignOut = async () => {
+    try {
+      await signOut();
+      toast.success("Signed out");
+    } catch (err) {
+      toast.error("Could not sign out. Please try again.");
+    }
   };
 
   return (
@@ -104,10 +117,17 @@ const Header = () => {
                     <DropdownMenuLabel>My Account</DropdownMenuLabel>
                     <DropdownMenuSeparator />
                     
-                    <DropdownMenuItem onSelect={handleOpenAuth} className="cursor-pointer">
-                      <LogIn className="mr-2 h-4 w-4" />
-                      <span>Sign In / Sign Up</span>
-                    </DropdownMenuItem>
+                    {isAuthenticated ? (
+                      <DropdownMenuItem onSelect={handleSignOut} className="cursor-pointer">
+                        <LogOut className="mr-2 h-4 w-4" />
+                        <span>Sign Out</span>
+                      </DropdownMenuItem>
+                    ) : (
+                      <DropdownMenuItem onSelect={handleOpenAuth} className="cursor-pointer">
+                        <LogIn className="mr-2 h-4 w-4" />
+                        <span>Sign In / Sign Up</span>
+                      </DropdownMenuItem>
+                    )}
                     
                     <DropdownMenuSeparator />
                     

--- a/src/components/LocationsNearby.tsx
+++ b/src/components/LocationsNearby.tsx
@@ -6,8 +6,8 @@ import { Button } from "@/components/ui/button";
 import { MapPin, ArrowRight, Navigation } from "lucide-react";
 import OpenStreetMap from "./map/OpenStreetMap";
 import { Location } from "@/types";
-import { getNearbyLocations } from "@/mock/cityLocations";
 import VerifiedIcon from "@/components/icons/VerifiedIcon";
+import { locationsRepo } from "@/services/data";
 
 const LocationsNearby = () => {
   const navigate = useNavigate();
@@ -17,30 +17,32 @@ const LocationsNearby = () => {
   const [userLocation, setUserLocation] = useState<GeolocationCoordinates | null>(null);
   const [nearbyLocations, setNearbyLocations] = useState<Location[]>([]);
   
-  // Get user's current location
+  // Get user's current location and load nearby venues from the data layer
+  // (Supabase with mock fallback).
   useEffect(() => {
+    const loadNearby = async (lat: number, lng: number) => {
+      try {
+        const locations = await locationsRepo.nearby(lat, lng);
+        setNearbyLocations(locations.slice(0, 3)); // Limit to 3 for this component
+      } catch (err) {
+        console.error("Error loading nearby locations:", err);
+        setNearbyLocations([]);
+      }
+    };
+
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
         (position) => {
           setUserLocation(position.coords);
-          
-          // Get nearby locations based on user coordinates
-          const userLat = position.coords.latitude;
-          const userLng = position.coords.longitude;
-          const locations = getNearbyLocations(userLat, userLng);
-          setNearbyLocations(locations.slice(0, 3)); // Limit to 3 for this component
+          loadNearby(position.coords.latitude, position.coords.longitude);
         },
         (error) => {
           console.error("Error getting location:", error);
-          // Use a default set of locations if geolocation fails
-          const defaultLocations = getNearbyLocations(34.0522, -118.2437); // Los Angeles
-          setNearbyLocations(defaultLocations.slice(0, 3));
+          loadNearby(34.0522, -118.2437); // Default: Los Angeles
         }
       );
     } else {
-      // Use a default set of locations if geolocation is not available
-      const defaultLocations = getNearbyLocations(34.0522, -118.2437); // Los Angeles
-      setNearbyLocations(defaultLocations.slice(0, 3));
+      loadNearby(34.0522, -118.2437); // Default: Los Angeles
     }
   }, []);
   

--- a/src/components/NearbyVibesMap.tsx
+++ b/src/components/NearbyVibesMap.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { useNavigate, useLocation as useRouterLocation } from "react-router-dom";
+import { useNavigate, useLocation as useRouterLocation, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import { useSimplifiedNearbyLocations } from "@/hooks/useSimplifiedNearbyLocations";
 import { geocodeAddress } from "@/utils/geocodingService";
@@ -49,18 +49,21 @@ const NearbyVibesMap: React.FC<NearbyVibesMapProps> = ({
   
   const navigate = useNavigate();
   const location = useRouterLocation();
-  
+  const { city: cityParam } = useParams<{ city?: string }>();
+
   useEffect(() => {
+    // Prefer the /explore/:city route param, then fall back to the ?q= query param.
     const params = new URLSearchParams(location.search);
     const q = params.get('q') || '';
-    
-    if (q) {
-      const city = q.split(',')[0].trim();
+    const source = cityParam || q;
+
+    if (source) {
+      const city = source.split(',')[0].trim();
       setSearchedCity(city);
     } else {
       setSearchedCity("");
     }
-  }, [location, setSearchedCity]);
+  }, [location, cityParam, setSearchedCity]);
 
   useEffect(() => {
     if (userLocation) {

--- a/src/components/PostFeed.tsx
+++ b/src/components/PostFeed.tsx
@@ -1,9 +1,8 @@
 
 import { useState, useEffect } from "react";
 import { Post, Comment } from "@/types";
-// Use centralized mock data imports
-import { mockPosts } from "@/mock/posts";
-import { mockComments } from "@/mock/comments";
+// Data layer: reads from Supabase, transparently falls back to mock data.
+import { postsRepo, commentsRepo } from "@/services/data";
 import PostCard from "./post/PostCard";
 import { useToast } from "@/hooks/use-toast";
 
@@ -14,15 +13,17 @@ interface PostFeedProps {
 
 const PostFeed = ({ celebrityFeatured = [], feedType = "for-you" }: PostFeedProps) => {
   const [posts, setPosts] = useState<Post[]>([]);
+  const [sourcePosts, setSourcePosts] = useState<Post[]>([]);
+  const [commentsByPost, setCommentsByPost] = useState<Record<string, Comment[]>>({});
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
 
   const getComments = (postId: string): Comment[] => {
-    return mockComments.filter(comment => comment.postId === postId);
+    return commentsByPost[postId] ?? [];
   };
 
   const getFilteredPosts = (type: string): Post[] => {
-    const allPosts = [...mockPosts];
+    const allPosts = [...sourcePosts];
     
     switch (type) {
       case "trending":
@@ -89,18 +90,34 @@ const PostFeed = ({ celebrityFeatured = [], feedType = "for-you" }: PostFeedProp
     }
   };
 
+  // Load the base post list once (from Supabase or mock fallback).
   useEffect(() => {
+    let active = true;
     setLoading(true);
-    
-    // Simulate loading delay
-    const timer = setTimeout(() => {
-      const filteredPosts = getFilteredPosts(feedType);
-      setPosts(filteredPosts);
-      setLoading(false);
-    }, 300);
+    postsRepo
+      .getFeed()
+      .then(async (fetched) => {
+        if (!active) return;
+        setSourcePosts(fetched);
+        // Fetch comments for the loaded posts in parallel.
+        const entries = await Promise.all(
+          fetched.map(async (p) => [p.id, await commentsRepo.getForPost(p.id)] as const),
+        );
+        if (!active) return;
+        setCommentsByPost(Object.fromEntries(entries));
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
-    return () => clearTimeout(timer);
-  }, [feedType, celebrityFeatured]);
+  // Re-apply sort/filter whenever the feed type, source posts, or comments change.
+  useEffect(() => {
+    setPosts(getFilteredPosts(feedType));
+  }, [feedType, celebrityFeatured, sourcePosts, commentsByPost]);
 
   const handlePostDeleted = (postId: string) => {
     setPosts(prev => prev.filter(post => post.id !== postId));

--- a/src/components/RecommendedForYou.tsx
+++ b/src/components/RecommendedForYou.tsx
@@ -4,11 +4,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
-import { mockLocations } from "@/mock/data";
 import { Location } from "@/types";
 import { MapPin, Users, Crown } from "lucide-react";
 import { getMediaForLocation } from "@/utils/map/locationMediaUtils";
 import { Badge } from "@/components/ui/badge";
+import { locationsRepo } from "@/services/data";
 
 interface RecommendedForYouProps {
   featuredLocations?: string[];
@@ -16,7 +16,22 @@ interface RecommendedForYouProps {
 
 const RecommendedForYou: React.FC<RecommendedForYouProps> = ({ featuredLocations }) => {
   const [locations, setLocations] = useState<Location[]>([]);
+  const [venuePool, setVenuePool] = useState<Location[]>([]);
   const [followStates, setFollowStates] = useState<Record<string, boolean>>({});
+
+  // Pull a pool of venues from the data layer (Supabase with mock fallback).
+  useEffect(() => {
+    let cancelled = false;
+    locationsRepo
+      .nearby(0, 0, 50)
+      .then((results) => {
+        if (!cancelled) setVenuePool(results);
+      })
+      .catch((err) => console.error("Error loading recommended venues:", err));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Mock user preferences for demonstration
   const userPreferences = ["Live Music", "Sports", "Outdoors", "Locally Owned"];
@@ -51,57 +66,59 @@ const RecommendedForYou: React.FC<RecommendedForYouProps> = ({ featuredLocations
   };
 
   useEffect(() => {
+    if (venuePool.length === 0) return;
+
     // Mix of featured, preference-matched, and premium venues
     let recommendedLocations: Location[] = [];
-    
+
     // First, get any explicitly featured locations
     if (featuredLocations && featuredLocations.length > 0) {
-      const locationMap = new Map(mockLocations.map(loc => [loc.id, loc]));
+      const locationMap = new Map(venuePool.map(loc => [loc.id, loc]));
       const filteredLocations = featuredLocations
         .map(id => locationMap.get(id))
         .filter((loc): loc is Location => loc !== undefined);
-      
+
       recommendedLocations = [...recommendedLocations, ...filteredLocations];
     }
-    
+
     // Add locations matching user preferences
-    const preferenceLocations = mockLocations.filter(location => {
+    const preferenceLocations = venuePool.filter(location => {
       // Make sure location.tags exists before trying to use it
       return location.tags && location.tags.some(tag => userPreferences.includes(tag));
     }).slice(0, 3);
-    
+
     // Add premium/promoted venues
-    const premiumLocations = mockLocations.filter(location => 
-      isPremiumVenue(location.id) && 
+    const premiumLocations = venuePool.filter(location =>
+      isPremiumVenue(location.id) &&
       !recommendedLocations.some(rec => rec.id === location.id) &&
       !preferenceLocations.some(pref => pref.id === location.id)
     ).slice(0, 2);
-    
+
     // Combine and limit to 5 recommendations
     recommendedLocations = [
       ...recommendedLocations,
-      ...preferenceLocations, 
+      ...preferenceLocations,
       ...premiumLocations
     ].slice(0, 5);
-    
+
     // If we still need more, add random locations
     if (recommendedLocations.length < 5) {
-      const randomLocations = mockLocations
+      const randomLocations = venuePool
         .filter(loc => !recommendedLocations.some(rec => rec.id === loc.id))
         .sort(() => 0.5 - Math.random())
         .slice(0, 5 - recommendedLocations.length);
-      
+
       recommendedLocations = [...recommendedLocations, ...randomLocations];
     }
-    
+
     setLocations(recommendedLocations);
 
     const initialFollowStates: Record<string, boolean> = {};
-    mockLocations.forEach(location => {
+    venuePool.forEach(location => {
       initialFollowStates[location.id] = false;
     });
     setFollowStates(initialFollowStates);
-  }, [featuredLocations]);
+  }, [featuredLocations, venuePool]);
 
   const toggleFollow = (locationId: string, e: React.MouseEvent) => {
     e.preventDefault();

--- a/src/components/TrendingLocations.tsx
+++ b/src/components/TrendingLocations.tsx
@@ -8,8 +8,25 @@ import { Location } from "@/types";
 import { mockLocations } from "@/mock/locations";
 import { getTrendingLocationsForCity } from "@/mock/cityLocations";
 import { toast } from "sonner";
+import { locationsRepo } from "@/services/data";
 
 const GOOGLE_MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+
+/**
+ * Resolve trending venues for a city through the data layer (Supabase with mock
+ * fallback). If the repo has no rows for the city, fall back to the curated mock list.
+ */
+const resolveTrendingForCity = async (city: string): Promise<Location[]> => {
+  try {
+    const fromRepo = await locationsRepo.byCity(city);
+    if (fromRepo && fromRepo.length > 0) {
+      return fromRepo.slice(0, 5);
+    }
+  } catch (err) {
+    console.error("Error loading trending locations:", err);
+  }
+  return getTrendingLocationsForCity(city);
+};
 
 // Event bus for updating trending locations from VernonChat
 export const eventBus = {
@@ -68,9 +85,9 @@ const TrendingLocations = () => {
                 if (cityComponent) {
                   const detectedCity = cityComponent.long_name;
                   setCurrentCity(detectedCity);
-                  
+
                   // Get trending locations for the detected city
-                  const cityTrending = getTrendingLocationsForCity(detectedCity);
+                  const cityTrending = await resolveTrendingForCity(detectedCity);
                   if (cityTrending.length > 0) {
                     setTrendingLocations(cityTrending);
                   }
@@ -80,16 +97,16 @@ const TrendingLocations = () => {
           } catch (error) {
             console.error("Error getting city from coordinates:", error);
             // Fall back to default trending locations
-            const defaultTrending = getTrendingLocationsForCity("Los Angeles");
+            const defaultTrending = await resolveTrendingForCity("Los Angeles");
             if (defaultTrending.length > 0) {
               setTrendingLocations(defaultTrending);
             }
           }
         },
-        (error) => {
+        async (error) => {
           console.error("Error getting location:", error);
           // Fall back to default trending locations
-          const defaultTrending = getTrendingLocationsForCity("Los Angeles");
+          const defaultTrending = await resolveTrendingForCity("Los Angeles");
           if (defaultTrending.length > 0) {
             setTrendingLocations(defaultTrending);
           }
@@ -101,10 +118,15 @@ const TrendingLocations = () => {
   // Initialize with trending locations for a default city if geolocation fails
   useEffect(() => {
     if (!geolocationAttempted) {
-      const defaultTrending = getTrendingLocationsForCity("Los Angeles");
-      if (defaultTrending.length > 0) {
-        setTrendingLocations(defaultTrending);
-      }
+      let cancelled = false;
+      resolveTrendingForCity("Los Angeles").then((defaultTrending) => {
+        if (!cancelled && defaultTrending.length > 0) {
+          setTrendingLocations(defaultTrending);
+        }
+      });
+      return () => {
+        cancelled = true;
+      };
     }
   }, [geolocationAttempted]);
   
@@ -123,10 +145,11 @@ const TrendingLocations = () => {
         toast.success(`Updated trending locations for ${cityName}`);
       } else {
         // If no events were provided, get trending locations for the city
-        const cityTrending = getTrendingLocationsForCity(cityName);
-        if (cityTrending.length > 0) {
-          setTrendingLocations(cityTrending);
-        }
+        resolveTrendingForCity(cityName).then((cityTrending) => {
+          if (cityTrending.length > 0) {
+            setTrendingLocations(cityTrending);
+          }
+        });
       }
     };
     

--- a/src/components/VLMChatBox.tsx
+++ b/src/components/VLMChatBox.tsx
@@ -11,6 +11,8 @@ import {
   Bot
 } from 'lucide-react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { OpenAIService } from '@/services/OpenAIService';
+import { getVenueRecommendations } from '@/components/VernonChat/utils/venueRecommendations';
 
 interface Message {
   id: string;
@@ -51,38 +53,56 @@ const VLMChatBox = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
   
-  const handleSendMessage = (e?: React.FormEvent) => {
+  const handleSendMessage = async (e?: React.FormEvent) => {
     if (e) e.preventDefault();
-    
+
     if (!inputValue.trim()) return;
-    
+
+    const prompt = inputValue;
+
     // Add user message
     const userMessage: Message = {
       id: Date.now().toString(),
-      text: inputValue,
+      text: prompt,
       sender: 'user',
       timestamp: new Date()
     };
-    
+
+    const history = messages.map(m => ({
+      sender: m.sender,
+      text: m.text,
+    }));
+
     setMessages(prev => [...prev, userMessage]);
     setInputValue('');
     setIsTyping(true);
-    
-    // Simulate AI thinking and typing
-    setTimeout(() => {
-      // Get random response from mockResponses
-      const randomResponse = mockResponses[Math.floor(Math.random() * mockResponses.length)];
-      
-      const aiMessage: Message = {
-        id: (Date.now() + 1).toString(),
-        text: randomResponse,
-        sender: 'ai',
-        timestamp: new Date()
-      };
-      
-      setMessages(prev => [...prev, aiMessage]);
-      setIsTyping(false);
-    }, 1500);
+
+    let responseText = '';
+    try {
+      // Prefer real venue recommendations when applicable, then the edge-backed
+      // AI completion chain (vertex-ai -> openai-chat -> canned).
+      const recommendation = await getVenueRecommendations(prompt);
+      responseText = recommendation
+        ? recommendation.text
+        : await OpenAIService.generateResponse(prompt, history, 'user');
+    } catch (error) {
+      console.error('VLM chat error:', error);
+    }
+
+    if (!responseText) {
+      // Final safety net: canned mock response so the chat always replies.
+      responseText = mockResponses[Math.floor(Math.random() * mockResponses.length)];
+    }
+
+    const aiMessage: Message = {
+      id: (Date.now() + 1).toString(),
+      text: responseText,
+      sender: 'ai',
+      timestamp: new Date()
+    };
+
+    setMessages(prev => [...prev, aiMessage]);
+    setIsTyping(false);
   };
   
   const toggleMinimize = () => {

--- a/src/components/VernonChat/utils/messageProcessor/processors/AIProcessor.ts
+++ b/src/components/VernonChat/utils/messageProcessor/processors/AIProcessor.ts
@@ -2,6 +2,7 @@
 import { MessageContext, MessageProcessor, ProcessingResult } from '../types';
 import { OpenAIService } from '@/services/OpenAIService';
 import { createAIMessage } from '../../messageFactory';
+import { getVenueRecommendations, isVenueRecommendationQuery } from '../../venueRecommendations';
 
 export class AIProcessor implements MessageProcessor {
   name = 'ai';
@@ -22,17 +23,32 @@ export class AIProcessor implements MessageProcessor {
       }));
       
       let responseText = '';
-      
-      try {
-        responseText = await OpenAIService.generateResponse(
-          context.query,
-          conversationContext,
-          context.isVenueMode ? 'venue' : 'user'
-        );
-        console.log('Got response from OpenAI:', responseText.substring(0, 50) + '...');
-      } catch (error) {
-        console.error('Error with OpenAI:', error);
-        responseText = "I'm having trouble connecting to my AI services right now. Please try again later.";
+
+      // If the user is asking for venue recommendations ("X near me", "places in
+      // <city>"), answer with REAL venue links from locationsRepo first.
+      if (!context.isVenueMode && isVenueRecommendationQuery(context.query)) {
+        try {
+          const recommendation = await getVenueRecommendations(context.query);
+          if (recommendation) {
+            responseText = recommendation.text;
+          }
+        } catch (error) {
+          console.error('Venue recommendation lookup failed:', error);
+        }
+      }
+
+      if (!responseText) {
+        try {
+          responseText = await OpenAIService.generateResponse(
+            context.query,
+            conversationContext,
+            context.isVenueMode ? 'venue' : 'user'
+          );
+          console.log('Got response from AI:', responseText.substring(0, 50) + '...');
+        } catch (error) {
+          console.error('Error with AI service:', error);
+          responseText = "I'm having trouble connecting to my AI services right now. Please try again later.";
+        }
       }
       
       const aiMessage = createAIMessage(responseText);

--- a/src/components/VernonChat/utils/venueRecommendations.ts
+++ b/src/components/VernonChat/utils/venueRecommendations.ts
@@ -1,0 +1,86 @@
+import { locationsRepo } from '@/services/data';
+import { Location } from '@/types';
+
+/**
+ * Vernon venue-recommendation helper.
+ *
+ * Detects "recommend / X near me / places in <city>" style intents and returns
+ * a markdown answer that links to REAL venues from `locationsRepo` (which is
+ * itself backed by Supabase with a mock-data fallback). Returns `null` when the
+ * query isn't a venue-recommendation request so the caller can fall through to
+ * the normal AI/search pipeline.
+ */
+
+const RECOMMEND_INTENT =
+  /\b(recommend|suggest|find me|looking for|where can i|places? to|things to do|good|best|near me|nearby|around here|in town)\b/i;
+
+const VENUE_NOUNS =
+  /\b(restaurant|restaurants|bar|bars|club|clubs|cafe|cafes|coffee|venue|venues|spot|spots|place|places|eat|drink|dinner|lunch|brunch|nightlife|museum|park|lounge|pub|food)\b/i;
+
+const CITY_PHRASE = /\b(?:in|near|around|at)\s+([A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)*)/;
+
+export interface VenueRecommendationResult {
+  text: string;
+  venues: Location[];
+}
+
+/**
+ * Returns true when the query looks like a request for venue recommendations.
+ */
+export function isVenueRecommendationQuery(query: string): boolean {
+  if (!query) return false;
+  return RECOMMEND_INTENT.test(query) && VENUE_NOUNS.test(query);
+}
+
+function venueLink(loc: Location): string {
+  const label = loc.name;
+  const href = `/venue/${encodeURIComponent(loc.id)}`;
+  const detail = [loc.type, loc.city].filter(Boolean).join(' • ');
+  const rating = loc.rating ? ` (${loc.rating}★)` : '';
+  return `- [${label}](${href})${rating}${detail ? ` — ${detail}` : ''}`;
+}
+
+/**
+ * Build a venue-recommendation answer with real venue links. Resolves to
+ * `null` if the query isn't a recommendation request.
+ */
+export async function getVenueRecommendations(
+  query: string,
+  coords?: { lat: number; lng: number }
+): Promise<VenueRecommendationResult | null> {
+  if (!isVenueRecommendationQuery(query)) return null;
+
+  let venues: Location[] = [];
+
+  try {
+    const cityMatch = query.match(CITY_PHRASE);
+    const wantsNearMe = /\bnear me\b|\bnearby\b|\baround here\b/i.test(query);
+
+    if (wantsNearMe && coords) {
+      venues = await locationsRepo.nearby(coords.lat, coords.lng, 6);
+    } else if (cityMatch && cityMatch[1]) {
+      venues = await locationsRepo.byCity(cityMatch[1].trim(), 6);
+      if (venues.length === 0) {
+        venues = await locationsRepo.search(query, 6);
+      }
+    } else {
+      venues = await locationsRepo.search(query, 6);
+    }
+  } catch (error) {
+    console.error('[getVenueRecommendations] error:', error);
+    return null;
+  }
+
+  if (venues.length === 0) return null;
+
+  const explore = `/explore?q=${encodeURIComponent(query)}`;
+  const text = [
+    "Here are some spots I think you'll love:",
+    '',
+    ...venues.map(venueLink),
+    '',
+    `[See more on the Explore page](${explore})`,
+  ].join('\n');
+
+  return { text, venues };
+}

--- a/src/components/check-in/CheckInDialog.tsx
+++ b/src/components/check-in/CheckInDialog.tsx
@@ -1,14 +1,15 @@
 
-import { useState } from "react";
-import { 
-  Dialog, 
-  DialogContent, 
-  DialogHeader, 
-  DialogTitle, 
+import { useRef, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
   DialogDescription,
   DialogFooter
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { ImagePlus, Loader2 } from "lucide-react";
 import { Location } from "@/types";
 import { PointsDisplay } from "./PointsDisplay";
 import { ReceiptUpload } from "./ReceiptUpload";
@@ -19,22 +20,35 @@ interface CheckInDialogProps {
   setIsOpen: (open: boolean) => void;
   isInRange: boolean;
   distance: string | null;
-  onConfirm: (pointsEarned: number) => void;
+  isSubmitting?: boolean;
+  onConfirm: (pointsEarned: number, photo?: File | null) => void;
 }
 
-export function CheckInDialog({ 
-  venue, 
-  isOpen, 
-  setIsOpen, 
-  isInRange, 
+export function CheckInDialog({
+  venue,
+  isOpen,
+  setIsOpen,
+  isInRange,
   distance,
-  onConfirm 
+  isSubmitting = false,
+  onConfirm
 }: CheckInDialogProps) {
   const [hasReceipt, setHasReceipt] = useState(false);
+  const [photo, setPhoto] = useState<File | null>(null);
+  const [photoPreview, setPhotoPreview] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handlePhotoSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setPhoto(file);
+    setPhotoPreview(URL.createObjectURL(file));
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
 
   const handleConfirmCheckIn = () => {
     const pointsEarned = hasReceipt ? 30 : 10;
-    onConfirm(pointsEarned);
+    onConfirm(pointsEarned, photo);
   };
 
   return (
@@ -54,25 +68,57 @@ export function CheckInDialog({
             )}
           </DialogDescription>
         </DialogHeader>
-        
+
         <div className="space-y-4 py-4">
           <PointsDisplay hasReceipt={hasReceipt} />
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*,video/*"
+            className="hidden"
+            onChange={handlePhotoSelected}
+          />
+          {photoPreview ? (
+            <div className="rounded-md overflow-hidden">
+              <img src={photoPreview} alt="Check-in" className="w-full h-40 object-cover" />
+            </div>
+          ) : null}
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <ImagePlus className="h-4 w-4 mr-2" />
+            {photo ? "Change photo" : "Add a photo (optional)"}
+          </Button>
+
           <ReceiptUpload onUploadComplete={() => setHasReceipt(true)} />
         </div>
-        
+
         <DialogFooter className="sm:justify-between">
           <Button
             variant="outline"
             onClick={() => setIsOpen(false)}
+            disabled={isSubmitting}
           >
             Cancel
           </Button>
           <Button
             className="bg-gradient-vibe"
             onClick={handleConfirmCheckIn}
-            disabled={!isInRange}
+            disabled={!isInRange || isSubmitting}
           >
-            {hasReceipt ? 'Check in (+30 points)' : 'Check in (+10 points)'}
+            {isSubmitting ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Checking in...
+              </>
+            ) : hasReceipt ? (
+              "Check in (+30 points)"
+            ) : (
+              "Check in (+10 points)"
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/explore/ExploreSearchSection.tsx
+++ b/src/components/explore/ExploreSearchSection.tsx
@@ -11,6 +11,7 @@ import { useGooglePlacesAutocomplete } from '@/hooks/useGooglePlacesAutocomplete
 interface ExploreSearchSectionProps {
   searchQuery: string;
   onSearchChange: (query: string) => void;
+  onSearchSubmit?: (query: string) => void;
   dateRange: { from: Date; to: Date } | null;
   onDateChange: (dates: { from: Date; to: Date } | null) => void;
   location: string;
@@ -22,6 +23,7 @@ interface ExploreSearchSectionProps {
 const ExploreSearchSection: React.FC<ExploreSearchSectionProps> = ({
   searchQuery,
   onSearchChange,
+  onSearchSubmit,
   dateRange,
   onDateChange,
   location,
@@ -106,6 +108,9 @@ const ExploreSearchSection: React.FC<ExploreSearchSectionProps> = ({
             placeholder="Search venues, events, activities..."
             value={searchQuery}
             onChange={(e) => onSearchChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') onSearchSubmit?.(searchQuery);
+            }}
             className="pl-10"
           />
         </div>

--- a/src/components/messaging/VenueMessaging.tsx
+++ b/src/components/messaging/VenueMessaging.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -7,30 +7,48 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Send, Settings, Bell, ChevronLeft } from "lucide-react";
+import { toast } from "sonner";
 import { useIsMobile } from '@/hooks/use-mobile';
 import { useUserSubscription } from '@/hooks/useUserSubscription';
-import { mockVenueConversations, MockVenueConversation, VenueMessage } from './mockVenueData';
+import { useUserStore } from '@/store';
+import { messagesRepo } from '@/services/data';
+import type { ChatConversation, ChatMessage } from '@/services/data';
+import { mockVenueConversations } from './mockVenueData';
 import MessageTypeBadge from './MessageTypeBadge';
 import VenueMessagingSettings from './VenueMessagingSettings';
 
 const VenueMessaging: React.FC = () => {
   const { hasFeature } = useUserSubscription();
+  const { user, isAuthenticated } = useUserStore();
   const isMobile = useIsMobile();
-  const [conversations, setConversations] = useState<MockVenueConversation[]>([]);
+  const [conversations, setConversations] = useState<ChatConversation[]>([]);
   const [selectedConversation, setSelectedConversation] = useState<string | null>(null);
-  const [messages, setMessages] = useState<VenueMessage[]>([]);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [newMessage, setNewMessage] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
   const [messagingEnabled, setMessagingEnabled] = useState(true);
+  const [sending, setSending] = useState(false);
+  const unsubscribeRef = useRef<(() => void) | null>(null);
 
   const canUseVenueMessaging = hasFeature('venueMessaging');
+  const userId = user?.id ?? null;
 
-  const loadConversations = useCallback(() => {
-    setConversations(mockVenueConversations);
-    if (mockVenueConversations.length > 0 && !selectedConversation) {
-      setSelectedConversation(mockVenueConversations[0].id);
+  const loadConversations = useCallback(async () => {
+    let convs: ChatConversation[] = [];
+    try {
+      if (userId) {
+        convs = await messagesRepo.listConversations(userId);
+      }
+    } catch (err) {
+      console.warn('[VenueMessaging] listConversations failed, using mock data', err);
     }
-  }, [selectedConversation]);
+    if (!convs || convs.length === 0) {
+      // Signed-out / empty-DB demo fallback.
+      convs = mockVenueConversations as unknown as ChatConversation[];
+    }
+    setConversations(convs);
+    setSelectedConversation((prev) => prev ?? (convs.length > 0 ? convs[0].id : null));
+  }, [userId]);
 
   useEffect(() => {
     if (canUseVenueMessaging) {
@@ -38,42 +56,87 @@ const VenueMessaging: React.FC = () => {
     }
   }, [canUseVenueMessaging, loadConversations]);
 
+  // Hydrate messages of the selected conversation + subscribe to live updates.
   useEffect(() => {
-    if (selectedConversation && conversations.length > 0) {
-      const conversation = conversations.find(c => c.id === selectedConversation);
-      if (conversation) {
-        setMessages(conversation.messages);
-        // Mark as read
-        setConversations(prev => prev.map(c => 
-          c.id === selectedConversation ? { ...c, unreadCount: 0 } : c
-        ));
+    if (!selectedConversation || conversations.length === 0) return;
+    const conversation = conversations.find((c) => c.id === selectedConversation);
+    if (!conversation) return;
+
+    setMessages(conversation.messages ?? []);
+    // Mark as read locally.
+    setConversations((prev) =>
+      prev.map((c) => (c.id === selectedConversation ? { ...c, unreadCount: 0 } : c)),
+    );
+
+    // Tear down any prior subscription and (only for real conversations) subscribe.
+    unsubscribeRef.current?.();
+    unsubscribeRef.current = null;
+    if (userId) {
+      try {
+        unsubscribeRef.current = messagesRepo.subscribe(selectedConversation, (incoming) => {
+          setMessages((prev) =>
+            prev.some((m) => m.id === incoming.id) ? prev : [...prev, incoming],
+          );
+        });
+      } catch (err) {
+        console.warn('[VenueMessaging] realtime subscribe failed', err);
       }
     }
-  }, [selectedConversation, conversations]);
-
-  const sendMessage = useCallback(() => {
-    if (!newMessage.trim() || !selectedConversation) return;
-
-    const message: VenueMessage = {
-      id: Date.now().toString(),
-      content: newMessage,
-      timestamp: new Date().toISOString(),
-      senderId: 'current-user',
-      senderName: 'You',
-      senderAvatar: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=100&h=100&fit=crop&auto=format',
-      senderType: 'user'
+    return () => {
+      unsubscribeRef.current?.();
+      unsubscribeRef.current = null;
     };
+  }, [selectedConversation, conversations, userId]);
 
-    setMessages(prev => [...prev, message]);
+  const sendMessage = useCallback(async () => {
+    const content = newMessage.trim();
+    if (!content || !selectedConversation || sending) return;
+
+    if (!isAuthenticated || !userId) {
+      toast.info('Sign in to send messages to venues.');
+      return;
+    }
+
+    setSending(true);
+    // Optimistic append.
+    const optimistic: ChatMessage = {
+      id: `optimistic-${Date.now()}`,
+      content,
+      timestamp: new Date().toISOString(),
+      senderId: userId,
+      senderName: 'You',
+      senderAvatar: user?.avatar ?? '',
+      senderType: 'user',
+      messageType: 'general',
+    };
+    setMessages((prev) => [...prev, optimistic]);
     setNewMessage('');
 
-    // Update the conversation's last message
-    setConversations(prev => prev.map(c => 
-      c.id === selectedConversation 
-        ? { ...c, lastMessage: message, messages: [...c.messages, message] }
-        : c
-    ));
-  }, [newMessage, selectedConversation]);
+    try {
+      const saved = await messagesRepo.sendMessage({
+        conversationId: selectedConversation,
+        senderId: userId,
+        content,
+        senderType: 'user',
+      });
+      // Swap the optimistic message for the persisted one.
+      setMessages((prev) => prev.map((m) => (m.id === optimistic.id ? saved : m)));
+      setConversations((prev) =>
+        prev.map((c) =>
+          c.id === selectedConversation
+            ? { ...c, lastMessage: saved, messages: [...c.messages, saved] }
+            : c,
+        ),
+      );
+    } catch (err) {
+      console.warn('[VenueMessaging] sendMessage failed', err);
+      setMessages((prev) => prev.filter((m) => m.id !== optimistic.id));
+      setNewMessage(content);
+      toast.error('Could not send your message. Please try again.');
+    } finally {
+      setSending(false);
+    }
+  }, [newMessage, selectedConversation, sending, isAuthenticated, userId, user?.avatar]);
 
   const filteredConversations = conversations.filter(conversation =>
     conversation.venueName.toLowerCase().includes(searchQuery.toLowerCase())
@@ -170,9 +233,11 @@ const VenueMessaging: React.FC = () => {
                             </Badge>
                           )}
                         </div>
-                        <Badge variant="outline" className="text-xs flex-shrink-0">
-                          {conversation.venueType}
-                        </Badge>
+                        {conversation.venueType && (
+                          <Badge variant="outline" className="text-xs flex-shrink-0">
+                            {conversation.venueType}
+                          </Badge>
+                        )}
                       </div>
                       {conversation.lastMessage && (
                         <div className="flex items-center gap-2 mb-1">
@@ -218,10 +283,14 @@ const VenueMessaging: React.FC = () => {
                   <div className="flex-1 min-w-0">
                     <h3 className="font-semibold text-sm truncate">{selectedConv.venueName}</h3>
                     <div className="flex items-center gap-2">
-                      <Badge variant="outline" className="text-xs">
-                        {selectedConv.venueType}
-                      </Badge>
-                      <p className="text-xs text-muted-foreground">{selectedConv.responseTime}</p>
+                      {selectedConv.venueType && (
+                        <Badge variant="outline" className="text-xs">
+                          {selectedConv.venueType}
+                        </Badge>
+                      )}
+                      {selectedConv.responseTime && (
+                        <p className="text-xs text-muted-foreground">{selectedConv.responseTime}</p>
+                      )}
                     </div>
                   </div>
                 </div>
@@ -280,7 +349,7 @@ const VenueMessaging: React.FC = () => {
                     disabled={!messagingEnabled}
                     className="flex-1"
                   />
-                  <Button onClick={sendMessage} disabled={!messagingEnabled} size="icon" className="h-10 w-10 flex-shrink-0">
+                  <Button onClick={sendMessage} disabled={!messagingEnabled || sending} size="icon" className="h-10 w-10 flex-shrink-0">
                     <Send className="h-4 w-4" />
                   </Button>
                 </div>

--- a/src/components/notifications/NotificationsDropdown.tsx
+++ b/src/components/notifications/NotificationsDropdown.tsx
@@ -1,136 +1,184 @@
 
-import React, { useState } from 'react';
-import { 
-  Bell, 
-  Music, 
-  Ticket, 
-  Gift, 
-  ShoppingBag, 
-  MessageSquarePlus, 
-  MapPin, 
-  Car, 
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Bell,
+  Music,
+  Ticket,
+  Gift,
+  MapPin,
+  Car,
   Award,
   CreditCard,
-  Building
+  Building,
+  Info,
 } from 'lucide-react';
-import { 
+import { useNavigate } from 'react-router-dom';
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuTrigger 
+  DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { notificationsRepo } from "@/services/data";
+import type { AppNotification } from "@/services/data";
+import { useUserStore } from "@/store";
 
-interface Notification {
-  id: string;
-  title: string;
-  description: string;
-  timestamp: string;
-  read: boolean;
-  type: 'event' | 'reward' | 'discount' | 'social' | 'trip' | 'connection' | 'offer';
-  icon: React.ReactNode;
+/** Demo fallback notifications used when signed out / DB empty so the panel never looks broken. */
+const FALLBACK_NOTIFICATIONS: AppNotification[] = [
+  {
+    id: 'demo-1',
+    type: 'event',
+    title: 'Drake is performing near you',
+    body: 'Drake is live at SoFi Stadium this weekend!',
+    read: false,
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
+  },
+  {
+    id: 'demo-2',
+    type: 'reward',
+    title: 'Redeem your VRN points',
+    body: 'You have enough points for a free coffee at Artisan Bakery',
+    read: false,
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 3).toISOString(),
+  },
+  {
+    id: 'demo-3',
+    type: 'discount',
+    title: "15% off at Mama's Fish Grill",
+    body: 'Use your VRN QR code in Apple Wallet to get 15% off',
+    read: false,
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
+  },
+  {
+    id: 'demo-4',
+    type: 'social',
+    title: 'Sunset Lounge pinned your post',
+    body: 'Your vibe at Sunset Lounge was pinned to their profile',
+    read: true,
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 2).toISOString(),
+  },
+  {
+    id: 'demo-5',
+    type: 'trip',
+    title: 'Trip booked!',
+    body: 'Your Vernon Concierge Trip is now booked',
+    read: true,
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7).toISOString(),
+  },
+];
+
+function iconForType(type: string): React.ReactNode {
+  switch (type) {
+    case 'event':
+      return <Ticket className="h-4 w-4 text-blue-500" />;
+    case 'reward':
+      return <Gift className="h-4 w-4 text-amber-500" />;
+    case 'discount':
+      return <CreditCard className="h-4 w-4 text-green-500" />;
+    case 'social':
+      return <MapPin className="h-4 w-4 text-red-500" />;
+    case 'offer':
+      return <Award className="h-4 w-4 text-indigo-500" />;
+    case 'trip':
+      return <Building className="h-4 w-4 text-teal-500" />;
+    case 'connection':
+      return <Car className="h-4 w-4 text-slate-500" />;
+    case 'music':
+      return <Music className="h-4 w-4 text-purple-500" />;
+    default:
+      return <Info className="h-4 w-4 text-muted-foreground" />;
+  }
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.round(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.round(hrs / 24);
+  if (days < 7) return `${days}d ago`;
+  return `${Math.round(days / 7)}w ago`;
 }
 
 const NotificationsDropdown = () => {
-  const [notifications, setNotifications] = useState<Notification[]>([
-    {
-      id: '1',
-      title: 'Drake is performing near you',
-      description: 'Drake is live at SoFi Stadium this weekend!',
-      timestamp: '2h ago',
-      read: false,
-      type: 'event',
-      icon: <Music className="h-4 w-4 text-purple-500" />
-    },
-    {
-      id: '2',
-      title: 'Redeem your VRN points',
-      description: 'You have enough points for a free coffee at Artisan Bakery',
-      timestamp: '3h ago',
-      read: false,
-      type: 'reward',
-      icon: <Gift className="h-4 w-4 text-amber-500" />
-    },
-    {
-      id: '3',
-      title: '15% off at Mama\'s Fish Grill',
-      description: 'Use your VRN QR code in Apple Wallet to get 15% off',
-      timestamp: '5h ago',
-      read: false,
-      type: 'discount',
-      icon: <CreditCard className="h-4 w-4 text-green-500" />
-    },
-    {
-      id: '4',
-      title: 'Clippers vs Lakers',
-      description: 'The Clippers are playing this week at Intuit Dome',
-      timestamp: '1d ago',
-      read: true,
-      type: 'event',
-      icon: <Ticket className="h-4 w-4 text-blue-500" />
-    },
-    {
-      id: '5',
-      title: 'Sunset Lounge pinned your post',
-      description: 'Your vibe at Sunset Lounge was pinned to their profile',
-      timestamp: '2d ago',
-      read: true,
-      type: 'social',
-      icon: <MapPin className="h-4 w-4 text-red-500" />
-    },
-    {
-      id: '6',
-      title: 'New influencer offers',
-      description: 'You have 3 offers in the VRN Influencer marketplace',
-      timestamp: '3d ago',
-      read: true,
-      type: 'offer',
-      icon: <Award className="h-4 w-4 text-indigo-500" />
-    },
-    {
-      id: '7',
-      title: 'Trip booked!',
-      description: 'Your Vernon Concierge Trip is now booked',
-      timestamp: '1w ago',
-      read: true,
-      type: 'trip',
-      icon: <Building className="h-4 w-4 text-teal-500" />
-    },
-    {
-      id: '8',
-      title: 'Uber Eats connected',
-      description: 'Your Uber Eats account is now connected',
-      timestamp: '1w ago',
-      read: true,
-      type: 'connection',
-      icon: <Car className="h-4 w-4 text-slate-500" />
+  const { user, isAuthenticated } = useUserStore();
+  const userId = user?.id ?? null;
+  const navigate = useNavigate();
+  const [notifications, setNotifications] = useState<AppNotification[]>([]);
+  const [usingFallback, setUsingFallback] = useState(false);
+
+  const load = useCallback(async () => {
+    let list: AppNotification[] = [];
+    try {
+      if (userId) {
+        list = await notificationsRepo.list(userId);
+      }
+    } catch (err) {
+      console.warn('[NotificationsDropdown] list failed', err);
     }
-  ]);
-  
-  const unreadCount = notifications.filter(n => !n.read).length;
-  
-  const markAsRead = (id: string) => {
-    setNotifications(notifications.map(n => 
-      n.id === id ? { ...n, read: true } : n
-    ));
-  };
-  
-  const markAllAsRead = () => {
-    setNotifications(notifications.map(n => ({ ...n, read: true })));
-  };
-  
+    if (!list || list.length === 0) {
+      setNotifications(FALLBACK_NOTIFICATIONS);
+      setUsingFallback(true);
+    } else {
+      setNotifications(list);
+      setUsingFallback(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  const markAsRead = useCallback(
+    async (id: string) => {
+      setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read: true } : n)));
+      if (!usingFallback && userId) {
+        try {
+          await notificationsRepo.markRead(id);
+        } catch (err) {
+          console.warn('[NotificationsDropdown] markRead failed', err);
+        }
+      }
+    },
+    [usingFallback, userId],
+  );
+
+  const markAllAsRead = useCallback(async () => {
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+    if (!usingFallback && userId) {
+      try {
+        await notificationsRepo.markAllRead(userId);
+      } catch (err) {
+        console.warn('[NotificationsDropdown] markAllRead failed', err);
+      }
+    }
+  }, [usingFallback, userId]);
+
+  const handleNotificationClick = useCallback(
+    (n: AppNotification) => {
+      markAsRead(n.id);
+      if (n.link) navigate(n.link);
+    },
+    [markAsRead, navigate],
+  );
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" size="icon" className="relative">
           <Bell className="h-[1.2rem] w-[1.2rem]" />
           {unreadCount > 0 && (
-            <Badge 
-              variant="destructive" 
+            <Badge
+              variant="destructive"
               className="absolute -top-1 -right-1 h-4 w-4 flex items-center justify-center p-0 text-[10px]"
             >
               {unreadCount}
@@ -143,9 +191,9 @@ const NotificationsDropdown = () => {
         <DropdownMenuLabel className="flex justify-between items-center">
           <span>Notifications</span>
           {unreadCount > 0 && (
-            <Button 
-              variant="ghost" 
-              size="sm" 
+            <Button
+              variant="ghost"
+              size="sm"
               className="text-xs h-6 px-2"
               onClick={markAllAsRead}
             >
@@ -154,7 +202,7 @@ const NotificationsDropdown = () => {
           )}
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-        
+
         <div className="max-h-80 overflow-y-auto">
           <DropdownMenuGroup>
             {notifications.length === 0 ? (
@@ -163,23 +211,22 @@ const NotificationsDropdown = () => {
               </div>
             ) : (
               notifications.map((notification) => (
-                <DropdownMenuItem 
-                  key={notification.id} 
+                <DropdownMenuItem
+                  key={notification.id}
                   className={`flex items-start p-3 gap-3 cursor-pointer ${notification.read ? '' : 'bg-muted/50'}`}
-                  onClick={() => markAsRead(notification.id)}
+                  onSelect={(e) => {
+                    e.preventDefault();
+                    handleNotificationClick(notification);
+                  }}
                 >
-                  <div className="mt-0.5">
-                    {notification.icon}
-                  </div>
+                  <div className="mt-0.5">{iconForType(notification.type)}</div>
                   <div className="flex-1 space-y-1">
-                    <p className="text-sm font-medium leading-none">
-                      {notification.title}
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      {notification.description}
-                    </p>
+                    <p className="text-sm font-medium leading-none">{notification.title}</p>
+                    {notification.body && (
+                      <p className="text-xs text-muted-foreground">{notification.body}</p>
+                    )}
                     <p className="text-xs text-muted-foreground/70">
-                      {notification.timestamp}
+                      {relativeTime(notification.createdAt)}
                     </p>
                   </div>
                   {!notification.read && (
@@ -190,13 +237,15 @@ const NotificationsDropdown = () => {
             )}
           </DropdownMenuGroup>
         </div>
-        
-        <DropdownMenuSeparator />
-        <div className="p-2">
-          <Button variant="outline" size="sm" className="w-full">
-            View all notifications
-          </Button>
-        </div>
+
+        {!isAuthenticated && (
+          <>
+            <DropdownMenuSeparator />
+            <p className="px-3 py-2 text-xs text-muted-foreground">
+              Sign in to see your real notifications.
+            </p>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/places/PlaceCard.tsx
+++ b/src/components/places/PlaceCard.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { MapPin, Star, Clock, Car, ExternalLink, BookmarkPlus } from "lucide-react";
 import { Location } from "@/types";
 import { toast } from "sonner";
+import { addUserPlace, getCurrentUserId } from "@/services/trips/tripCollabService";
 
 type PlaceCardProps = {
   place: Location;
@@ -51,8 +52,25 @@ const PlaceCard = ({ place, visitType }: PlaceCardProps) => {
   const rideServiceUrl = getRideServiceUrl(place);
   const officialUrl = getOfficialUrl(place);
   
-  const handleSaveToWantToVisit = () => {
-    toast.success(`Added ${place.name} to your "Want to Visit" list`);
+  const handleSaveToWantToVisit = async () => {
+    const uid = await getCurrentUserId();
+    if (!uid) {
+      toast.error('Please sign in to save places');
+      return;
+    }
+    try {
+      await addUserPlace({
+        user_id: uid,
+        location_id: place.id,
+        location_name: place.name,
+        location_city: place.city,
+        status: "want_to_visit",
+      });
+      toast.success(`Added ${place.name} to your "Want to Visit" list`);
+    } catch (err) {
+      console.error('[PlaceCard] save failed:', err);
+      toast.error('Failed to save place');
+    }
   };
   
   return (

--- a/src/components/places/TripDetails.tsx
+++ b/src/components/places/TripDetails.tsx
@@ -12,6 +12,8 @@ import { AddPlaceDialog } from "./trip/AddPlaceDialog";
 import { EmptyPlaceState } from "./trip/EmptyPlaceState";
 import TripCommunicationHub from "./trip/TripCommunicationHub";
 import { useTripPlaces } from "./trip/useTripPlaces";
+import { tripsRepo } from "@/services/data";
+import { listTripMembers } from "@/services/trips/tripCollabService";
 
 // Mock colors for users
 const userColors = [
@@ -27,20 +29,60 @@ const TripDetails = () => {
   const navigate = useNavigate();
   const [trip, setTrip] = React.useState<any>(null);
   
-  // Fetch trip data
+  // Fetch trip data: prefer the data layer (Supabase + mock fallback), and fall
+  // back to any locally-stored offline trip if the repo can't resolve it.
   React.useEffect(() => {
-    // In a real app, this would be an API call
-    const storedTrips = localStorage.getItem('trips');
-    let tripsData = storedTrips ? JSON.parse(storedTrips) : [];
-    
-    const foundTrip = tripsData.find((t: any) => t.id === tripId);
-    
-    if (foundTrip) {
-      setTrip(foundTrip);
-    } else {
-      toast.error("Trip not found");
-      navigate("/my-places");
-    }
+    let cancelled = false;
+
+    const loadTrip = async () => {
+      if (!tripId) return;
+
+      try {
+        const record = await tripsRepo.getById(tripId);
+        if (record) {
+          const members = await listTripMembers(tripId);
+          if (cancelled) return;
+          setTrip({
+            id: record.id,
+            name: record.name,
+            destination: record.description || "Trip",
+            description: record.description || "",
+            startDate: record.startDate || new Date().toISOString().split("T")[0],
+            endDate: record.endDate || new Date().toISOString().split("T")[0],
+            collaborators:
+              members.length > 0
+                ? members
+                : [{ id: "1", name: "You", avatar: "/placeholder.svg" }],
+          });
+          return;
+        }
+      } catch (err) {
+        console.warn("[TripDetails] repo lookup failed, trying local:", err);
+      }
+
+      // Offline fallback: locally-stored trips.
+      try {
+        const storedTrips = localStorage.getItem("trips");
+        const tripsData = storedTrips ? JSON.parse(storedTrips) : [];
+        const foundTrip = tripsData.find((t: any) => t.id === tripId);
+        if (foundTrip && !cancelled) {
+          setTrip(foundTrip);
+          return;
+        }
+      } catch {
+        // ignore
+      }
+
+      if (!cancelled) {
+        toast.error("Trip not found");
+        navigate("/my-places");
+      }
+    };
+
+    loadTrip();
+    return () => {
+      cancelled = true;
+    };
   }, [tripId, navigate]);
 
   const {

--- a/src/components/places/trip/TripChatWindow.tsx
+++ b/src/components/places/trip/TripChatWindow.tsx
@@ -3,11 +3,17 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Send, Search, ThumbsUp, ThumbsDown, Heart } from "lucide-react";
-import { db } from '@/services/database';
-import { TripMessage } from '@/services/database/repositories/TripRepository';
 import { toast } from "sonner";
 import { formatDistanceToNow } from "date-fns";
 import { supabase } from "@/integrations/supabase/client";
+import {
+  listTripMessages,
+  sendTripMessage,
+  getCurrentUserId,
+  TripMessageRecord,
+} from "@/services/trips/tripCollabService";
+
+type TripMessage = TripMessageRecord;
 
 interface TripChatWindowProps {
   tripId: string;
@@ -39,14 +45,16 @@ const TripChatWindow: React.FC<TripChatWindowProps> = ({
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const currentUser = {
-    id: "current-user",
-    name: "Current User",
-    avatar: "/placeholder.svg"
+    id: collaborators[0]?.id || "current-user",
+    name: collaborators[0]?.name || "You",
+    avatar: collaborators[0]?.avatar || "/placeholder.svg"
   };
 
   useEffect(() => {
     fetchMessages();
-    subscribeToMessages();
+    const unsubscribe = subscribeToMessages();
+    return unsubscribe;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tripId]);
 
   useEffect(() => {
@@ -59,12 +67,12 @@ const TripChatWindow: React.FC<TripChatWindowProps> = ({
 
   const fetchMessages = async () => {
     try {
-      // First get messages
-      const messagesResult = await db.trips.getMessages(tripId);
-      if (messagesResult.success && messagesResult.data) {
-        // Then get reactions via direct Supabase call for now
-        const { data: messagesWithReactions, error } = await supabase
-          .from('trip_messages')
+      const rows = await listTripMessages(tripId);
+      // Try to enrich with reactions, but don't fail the view if that table
+      // isn't present.
+      try {
+        const { data, error } = await supabase
+          .from('trip_messages' as any)
           .select(`
             *,
             trip_message_reactions (
@@ -75,72 +83,85 @@ const TripChatWindow: React.FC<TripChatWindowProps> = ({
           `)
           .eq('trip_id', tripId)
           .order('created_at', { ascending: true });
-
-        if (error) throw error;
-        setMessages(messagesWithReactions || []);
-      } else if (messagesResult.error) {
-        console.error('Error fetching messages:', messagesResult.error);
-        toast.error('Failed to load messages');
+        if (!error && data && data.length > 0) {
+          setMessages(data as ChatMessage[]);
+          return;
+        }
+      } catch {
+        // ignore reaction enrichment failure
       }
+      setMessages(rows as ChatMessage[]);
     } catch (error) {
       console.error('Error fetching messages:', error);
-      toast.error('Failed to load messages');
     } finally {
       setIsLoading(false);
     }
   };
 
   const subscribeToMessages = () => {
-    const channel = supabase
-      .channel(`trip-messages-${tripId}`)
-      .on(
-        'postgres_changes',
-        {
-          event: 'INSERT',
-          schema: 'public',
-          table: 'trip_messages',
-          filter: `trip_id=eq.${tripId}`
-        },
-        (payload) => {
-          setMessages(prev => [...prev, payload.new as ChatMessage]);
-        }
-      )
-      .on(
-        'postgres_changes',
-        {
-          event: 'INSERT',
-          schema: 'public',
-          table: 'trip_message_reactions'
-        },
-        () => {
-          fetchMessages(); // Refresh to get updated reactions
-        }
-      )
-      .subscribe();
+    try {
+      const channel = supabase
+        .channel(`trip-messages-${tripId}`)
+        .on(
+          'postgres_changes',
+          {
+            event: 'INSERT',
+            schema: 'public',
+            table: 'trip_messages',
+            filter: `trip_id=eq.${tripId}`
+          },
+          (payload) => {
+            setMessages(prev => {
+              const incoming = payload.new as ChatMessage;
+              if (prev.some(m => m.id === incoming.id)) return prev;
+              return [...prev, incoming];
+            });
+          }
+        )
+        .on(
+          'postgres_changes',
+          {
+            event: 'INSERT',
+            schema: 'public',
+            table: 'trip_message_reactions'
+          },
+          () => {
+            fetchMessages(); // Refresh to get updated reactions
+          }
+        )
+        .subscribe();
 
-    return () => {
-      supabase.removeChannel(channel);
-    };
+      return () => {
+        supabase.removeChannel(channel);
+      };
+    } catch (err) {
+      console.warn('[TripChatWindow] realtime subscribe failed:', err);
+      return () => {};
+    }
   };
 
   const sendMessage = async () => {
     if (!newMessage.trim()) return;
 
+    const uid = await getCurrentUserId();
+    if (!uid) {
+      toast.error('Please sign in to send a message');
+      return;
+    }
+
     try {
-      const result = await db.trips.sendMessage({
+      const created = await sendTripMessage({
         trip_id: tripId,
         content: newMessage,
-        user_id: currentUser.id,
+        user_id: uid,
         user_name: currentUser.name,
         user_avatar: currentUser.avatar,
         message_type: 'text'
       });
-
-      if (result.success) {
-        setNewMessage('');
-      } else {
-        throw result.error || new Error('Failed to send message');
-      }
+      setNewMessage('');
+      setMessages(prev =>
+        prev.some(m => m.id === created.id) ? prev : [...prev, created as ChatMessage],
+      );
     } catch (error) {
       console.error('Error sending message:', error);
       toast.error('Failed to send message');
@@ -148,17 +169,22 @@ const TripChatWindow: React.FC<TripChatWindowProps> = ({
   };
 
   const addReaction = async (messageId: string, reactionType: string) => {
+    const uid = await getCurrentUserId();
+    if (!uid) {
+      toast.error('Please sign in to react');
+      return;
+    }
     try {
-      const result = await db.trips.addReaction({
-        message_id: messageId,
-        reaction_type: reactionType,
-        user_id: currentUser.id,
-        user_name: currentUser.name
-      });
-
-      if (!result.success) {
-        throw result.error || new Error('Failed to add reaction');
-      }
+      const { error } = await supabase
+        .from('trip_message_reactions' as any)
+        .insert({
+          message_id: messageId,
+          reaction_type: reactionType,
+          user_id: uid,
+          user_name: currentUser.name,
+        });
+      if (error) throw error;
+      fetchMessages();
     } catch (error) {
       console.error('Error adding reaction:', error);
       toast.error('Failed to add reaction');

--- a/src/components/places/trip/TripIdeasSection.tsx
+++ b/src/components/places/trip/TripIdeasSection.tsx
@@ -5,11 +5,16 @@ import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { PlusCircle, MapPin, Star, ThumbsUp, ThumbsDown } from "lucide-react";
 import { Dialog, DialogTrigger } from "@/components/ui/dialog";
-import { db } from '@/services/database';
-import { TripVenueIdea } from '@/services/database/repositories/TripRepository';
 import { toast } from "sonner";
 import AddVenueIdeaDialog from './AddVenueIdeaDialog';
 import { supabase } from "@/integrations/supabase/client";
+import {
+  listVenueIdeas,
+  proposeVenueIdea,
+  voteOnVenueIdea,
+  getCurrentUserId,
+  VenueIdeaRecord,
+} from "@/services/trips/tripCollabService";
 
 interface TripIdeasSectionProps {
   tripId: string;
@@ -21,14 +26,7 @@ interface TripIdeasSectionProps {
   userColors: Array<{ id: string; color: string }>;
 }
 
-interface VenueIdea extends TripVenueIdea {
-  trip_venue_votes?: Array<{
-    id: string;
-    vote_type: 'up' | 'down';
-    user_name: string;
-    user_avatar: string;
-  }>;
-}
+type VenueIdea = VenueIdeaRecord;
 
 const TripIdeasSection: React.FC<TripIdeasSectionProps> = ({
   tripId,
@@ -39,90 +37,95 @@ const TripIdeasSection: React.FC<TripIdeasSectionProps> = ({
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
+  // Display identity for the current user; falls back to a generic label when
+  // signed out so the UI still renders.
   const currentUser = {
-    id: "current-user",
-    name: "Current User",
-    avatar: "/placeholder.svg"
+    id: collaborators[0]?.id || "current-user",
+    name: collaborators[0]?.name || "You",
+    avatar: collaborators[0]?.avatar || "/placeholder.svg"
   };
 
   useEffect(() => {
     fetchVenueIdeas();
-    subscribeToVenueIdeas();
+    const unsubscribe = subscribeToVenueIdeas();
+    return unsubscribe;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tripId]);
 
   const fetchVenueIdeas = async () => {
     try {
-      const result = await db.trips.getVenueIdeas(tripId);
-      if (result.success && result.data) {
-        setVenueIdeas(result.data as VenueIdea[]);
-      } else if (result.error) {
-        console.error('Error fetching venue ideas:', result.error);
-        toast.error('Failed to load venue ideas');
-      }
+      const ideas = await listVenueIdeas(tripId);
+      setVenueIdeas(ideas);
     } catch (error) {
       console.error('Error fetching venue ideas:', error);
-      toast.error('Failed to load venue ideas');
     } finally {
       setIsLoading(false);
     }
   };
 
   const subscribeToVenueIdeas = () => {
-    const channel = supabase
-      .channel(`trip-venue-ideas-${tripId}`)
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'trip_venue_ideas',
-          filter: `trip_id=eq.${tripId}`
-        },
-        () => {
-          fetchVenueIdeas();
-        }
-      )
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'trip_venue_votes'
-        },
-        () => {
-          fetchVenueIdeas();
-        }
-      )
-      .subscribe();
+    try {
+      const channel = supabase
+        .channel(`trip-venue-ideas-${tripId}`)
+        .on(
+          'postgres_changes',
+          {
+            event: '*',
+            schema: 'public',
+            table: 'trip_venue_ideas',
+            filter: `trip_id=eq.${tripId}`
+          },
+          () => {
+            fetchVenueIdeas();
+          }
+        )
+        .on(
+          'postgres_changes',
+          {
+            event: '*',
+            schema: 'public',
+            table: 'trip_venue_votes'
+          },
+          () => {
+            fetchVenueIdeas();
+          }
+        )
+        .subscribe();
 
-    return () => {
-      supabase.removeChannel(channel);
-    };
+      return () => {
+        supabase.removeChannel(channel);
+      };
+    } catch (err) {
+      // Realtime is a nice-to-have; never let it break the view.
+      console.warn('[TripIdeasSection] realtime subscribe failed:', err);
+      return () => {};
+    }
   };
 
   const addVenueIdea = async (venueData: any) => {
+    const uid = await getCurrentUserId();
+    if (!uid) {
+      toast.error('Please sign in to propose a venue');
+      return;
+    }
     try {
-      const result = await db.trips.addVenueIdea({
+      await proposeVenueIdea({
         trip_id: tripId,
-        venue_id: venueData.id,
+        venue_id: String(venueData.id),
         venue_name: venueData.name,
         venue_address: venueData.address,
         venue_city: venueData.city,
         venue_rating: venueData.rating,
         venue_image_url: venueData.image_url,
-        proposed_by_id: currentUser.id,
+        proposed_by_id: uid,
         proposed_by_name: currentUser.name,
         proposed_by_avatar: currentUser.avatar,
         notes: venueData.notes || '',
         status: 'pending'
       });
-
-      if (result.success) {
-        toast.success('Venue idea added successfully!');
-        setIsDialogOpen(false);
-      } else {
-        throw result.error || new Error('Failed to add venue idea');
-      }
+      toast.success('Venue idea added successfully!');
+      setIsDialogOpen(false);
+      fetchVenueIdeas();
     } catch (error) {
       console.error('Error adding venue idea:', error);
       toast.error('Failed to add venue idea');
@@ -130,6 +133,11 @@ const TripIdeasSection: React.FC<TripIdeasSectionProps> = ({
   };
 
   const voteOnVenue = async (venueIdeaId: string, voteType: 'up' | 'down') => {
+    const uid = await getCurrentUserId();
+    if (!uid) {
+      toast.error('Please sign in to vote');
+      return;
+    }
     try {
       // Check if user already voted
       const existingVote = venueIdeas
@@ -141,19 +149,15 @@ const TripIdeasSection: React.FC<TripIdeasSectionProps> = ({
         return;
       }
 
-      const result = await db.trips.voteOnVenue({
+      await voteOnVenueIdea({
         venue_idea_id: venueIdeaId,
         vote_type: voteType,
-        user_id: currentUser.id,
+        user_id: uid,
         user_name: currentUser.name,
         user_avatar: currentUser.avatar
       });
-
-      if (result.success) {
-        toast.success('Vote recorded!');
-      } else {
-        throw result.error || new Error('Failed to record vote');
-      }
+      toast.success('Vote recorded!');
+      fetchVenueIdeas();
     } catch (error) {
       console.error('Error voting:', error);
       toast.error('Failed to record vote');

--- a/src/components/places/trip/useTripManager.ts
+++ b/src/components/places/trip/useTripManager.ts
@@ -1,16 +1,18 @@
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { mockUsers } from "@/mock/data";
 import { DateRange } from 'react-day-picker';
 import { toast } from "sonner";
+import { tripsRepo, USE_MOCK_FALLBACK } from "@/services/data";
+import { getCurrentUserId } from "@/services/trips/tripCollabService";
 
 interface Trip {
   id: string;
   name: string;
   destination: string;
   description: string;
-  startDate: string; // Changed from Date to string to fix the type error
-  endDate: string; // Changed from Date to string to fix the type error
+  startDate: string;
+  endDate: string;
   collaborators: {
     id: string;
     name: string;
@@ -21,6 +23,7 @@ interface Trip {
 
 interface UseTripManagerReturn {
   trips: Trip[];
+  isLoading: boolean;
   createTrip: (tripData: {
     name: string;
     destination: string;
@@ -31,79 +34,128 @@ interface UseTripManagerReturn {
   inviteUserToTrip: (tripId: string, email: string) => void;
 }
 
+const LOCAL_KEY = 'trips';
+const today = new Date();
+const fmt = (d: Date) => d.toISOString().split('T')[0];
+
+/**
+ * Local/mock trips used as an offline fallback when there is no signed-in user.
+ * Kept in localStorage so demo edits survive a refresh while signed out.
+ */
+const getDefaultTrips = (): Trip[] => [
+  {
+    id: "1",
+    name: "Summer in Paris",
+    destination: "Paris, France",
+    description: "Family vacation exploring the City of Light",
+    startDate: fmt(new Date(today.getFullYear(), today.getMonth() + 1, 15)),
+    endDate: fmt(new Date(today.getFullYear(), today.getMonth() + 1, 22)),
+    collaborators: [
+      { id: "1", name: mockUsers[0].name, avatar: mockUsers[0].avatar },
+      { id: "2", name: "Mom", avatar: mockUsers[1].avatar },
+      { id: "3", name: "Stacy", avatar: mockUsers[2].avatar },
+    ],
+    savedPlaces: 8,
+  },
+  {
+    id: "2",
+    name: "Tokyo Adventure",
+    destination: "Tokyo, Japan",
+    description: "Exploring Japanese culture and cuisine",
+    startDate: fmt(new Date(today.getFullYear(), today.getMonth() + 4, 5)),
+    endDate: fmt(new Date(today.getFullYear(), today.getMonth() + 4, 15)),
+    collaborators: [
+      { id: "1", name: mockUsers[0].name, avatar: mockUsers[0].avatar },
+      { id: "4", name: "Dave", avatar: mockUsers[3].avatar },
+      { id: "5", name: "Alex", avatar: mockUsers[4].avatar },
+    ],
+    savedPlaces: 5,
+  },
+];
+
+function loadLocalTrips(): Trip[] {
+  const stored = localStorage.getItem(LOCAL_KEY);
+  if (stored) {
+    try {
+      return JSON.parse(stored);
+    } catch (err) {
+      console.error('Error parsing stored trips:', err);
+    }
+  }
+  const defaults = getDefaultTrips();
+  localStorage.setItem(LOCAL_KEY, JSON.stringify(defaults));
+  return defaults;
+}
+
+function saveLocalTrips(trips: Trip[]) {
+  localStorage.setItem(LOCAL_KEY, JSON.stringify(trips));
+}
+
+/**
+ * Maps a TripRecord from the data layer into the shape the trip UI expects.
+ * `destination` is derived from the description (the trips table has no
+ * dedicated destination column) and dates fall back to today so date-fns
+ * parsing in TripCard never throws.
+ */
+function mapRecordToTrip(record: {
+  id: string;
+  name: string;
+  description?: string;
+  startDate?: string;
+  endDate?: string;
+}, collaborators: Trip['collaborators']): Trip {
+  return {
+    id: record.id,
+    name: record.name,
+    destination: record.description || "Trip",
+    description: record.description || "",
+    startDate: record.startDate || fmt(today),
+    endDate: record.endDate || fmt(today),
+    collaborators: collaborators.length > 0
+      ? collaborators
+      : [{ id: "1", name: mockUsers[0].name, avatar: mockUsers[0].avatar }],
+    savedPlaces: 0,
+  };
+}
+
 export const useTripManager = (): UseTripManagerReturn => {
   const [trips, setTrips] = useState<Trip[]>([]);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
-  // Initialize trips from localStorage or defaults
-  useEffect(() => {
-    const storedTrips = localStorage.getItem('trips');
-    if (storedTrips) {
-      try {
-        // Parse dates correctly
-        const parsedTrips = JSON.parse(storedTrips);
-        setTrips(parsedTrips);
-      } catch (err) {
-        console.error('Error parsing stored trips:', err);
-        // Fallback to default trips
-        setTrips(getDefaultTrips());
+  const loadTrips = useCallback(async () => {
+    setIsLoading(true);
+    const uid = await getCurrentUserId();
+    setUserId(uid);
+
+    if (!uid) {
+      // Signed out: local/mock fallback only.
+      setTrips(loadLocalTrips());
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const records = await tripsRepo.listForUser(uid);
+      setTrips(records.map((r) => mapRecordToTrip(r, [])));
+    } catch (err) {
+      console.warn('[useTripManager] falling back to local trips:', err);
+      if (USE_MOCK_FALLBACK) {
+        setTrips(loadLocalTrips());
+      } else {
+        toast.error('Failed to load trips');
+        setTrips([]);
       }
-    } else {
-      // Use default trips
-      const defaultTrips = getDefaultTrips();
-      setTrips(defaultTrips);
-      // Save to localStorage
-      localStorage.setItem('trips', JSON.stringify(defaultTrips));
+    } finally {
+      setIsLoading(false);
     }
   }, []);
 
-  const getDefaultTrips = (): Trip[] => {
-    return [
-      {
-        id: "1",
-        name: "Summer in Paris",
-        destination: "Paris, France",
-        description: "Family vacation exploring the City of Light",
-        startDate: "2025-07-15",
-        endDate: "2025-07-22",
-        collaborators: [
-          { id: "1", name: mockUsers[0].name, avatar: mockUsers[0].avatar },
-          { id: "2", name: "Mom", avatar: mockUsers[1].avatar },
-          { id: "3", name: "Stacy", avatar: mockUsers[2].avatar },
-        ],
-        savedPlaces: 8
-      },
-      {
-        id: "2",
-        name: "Tokyo Adventure",
-        destination: "Tokyo, Japan",
-        description: "Exploring Japanese culture and cuisine",
-        startDate: "2025-10-05",
-        endDate: "2025-10-15",
-        collaborators: [
-          { id: "1", name: mockUsers[0].name, avatar: mockUsers[0].avatar },
-          { id: "4", name: "Dave", avatar: mockUsers[3].avatar },
-          { id: "5", name: "Alex", avatar: mockUsers[4].avatar },
-        ],
-        savedPlaces: 5
-      },
-      {
-        id: "3",
-        name: "Bali Getaway",
-        destination: "Bali, Indonesia",
-        description: "Beach relaxation and cultural exploration",
-        startDate: "2025-12-10",
-        endDate: "2025-12-20",
-        collaborators: [
-          { id: "1", name: mockUsers[0].name, avatar: mockUsers[0].avatar },
-          { id: "6", name: "Emma", avatar: mockUsers[5].avatar },
-          { id: "7", name: "Mike", avatar: mockUsers[6].avatar },
-        ],
-        savedPlaces: 6
-      }
-    ];
-  };
+  useEffect(() => {
+    loadTrips();
+  }, [loadTrips]);
 
-  const createTrip = (tripData: {
+  const createTrip = async (tripData: {
     name: string;
     destination: string;
     description: string;
@@ -113,76 +165,114 @@ export const useTripManager = (): UseTripManagerReturn => {
       toast.error("Please fill in all required fields");
       return;
     }
-    
-    const newTrip: Trip = {
-      id: Date.now().toString(),
-      name: tripData.name,
-      destination: tripData.destination,
-      description: tripData.description,
-      startDate: tripData.dateRange.from.toISOString().split('T')[0],
-      endDate: tripData.dateRange.to.toISOString().split('T')[0],
-      collaborators: [
-        { id: "1", name: mockUsers[0].name, avatar: mockUsers[0].avatar },
-      ],
-      savedPlaces: 0
-    };
-    
-    const updatedTrips = [...trips, newTrip];
-    setTrips(updatedTrips);
-    
-    // Save to localStorage
-    localStorage.setItem('trips', JSON.stringify(updatedTrips));
-    toast.success("Trip created successfully!");
+
+    const startDate = fmt(tripData.dateRange.from);
+    const endDate = fmt(tripData.dateRange.to);
+    // Persist destination inside the description so it survives a reload.
+    const description = tripData.description
+      ? `${tripData.destination} — ${tripData.description}`
+      : tripData.destination;
+
+    if (!userId) {
+      // Offline/local create.
+      const newTrip: Trip = {
+        id: Date.now().toString(),
+        name: tripData.name,
+        destination: tripData.destination,
+        description: tripData.description,
+        startDate,
+        endDate,
+        collaborators: [{ id: "1", name: mockUsers[0].name, avatar: mockUsers[0].avatar }],
+        savedPlaces: 0,
+      };
+      const updated = [...trips, newTrip];
+      setTrips(updated);
+      saveLocalTrips(updated);
+      toast.success("Trip created (offline). Sign in to sync.");
+      return;
+    }
+
+    try {
+      const record = await tripsRepo.create({
+        ownerId: userId,
+        name: tripData.name,
+        description,
+        startDate,
+        endDate,
+      });
+      const newTrip = mapRecordToTrip(record, []);
+      newTrip.destination = tripData.destination;
+      setTrips((prev) => [newTrip, ...prev]);
+      toast.success("Trip created successfully!");
+    } catch (err) {
+      console.error('[useTripManager] createTrip failed:', err);
+      toast.error("Failed to create trip");
+    }
   };
 
-  const deleteTrip = (tripId: string) => {
-    const updatedTrips = trips.filter(trip => trip.id !== tripId);
-    setTrips(updatedTrips);
-    
-    // Save to localStorage
-    localStorage.setItem('trips', JSON.stringify(updatedTrips));
-    toast.success("Trip deleted successfully");
+  const deleteTrip = async (tripId: string) => {
+    if (!userId) {
+      const updated = trips.filter((trip) => trip.id !== tripId);
+      setTrips(updated);
+      saveLocalTrips(updated);
+      toast.success("Trip deleted");
+      return;
+    }
+
+    try {
+      await tripsRepo.remove(tripId);
+      setTrips((prev) => prev.filter((trip) => trip.id !== tripId));
+      toast.success("Trip deleted successfully");
+    } catch (err) {
+      console.error('[useTripManager] deleteTrip failed:', err);
+      toast.error("Failed to delete trip");
+    }
   };
 
-  const inviteUserToTrip = (tripId: string, email: string) => {
+  const inviteUserToTrip = async (tripId: string, email: string) => {
     if (!email) {
       toast.error("Please enter an email address");
       return;
     }
-    
-    // Find the trip
-    const trip = trips.find(t => t.id === tripId);
-    if (trip) {
-      // In a real app, this would send an email invitation
-      // For now, we'll just simulate adding a user
-      const updatedTrips = trips.map(t => {
-        if (t.id === tripId) {
-          // Add a mock user
-          const newCollaborator = {
-            id: (t.collaborators.length + 1).toString(),
-            name: `Invited User ${t.collaborators.length + 1}`,
-            avatar: mockUsers[Math.floor(Math.random() * mockUsers.length)].avatar
-          };
-          
-          return {
-            ...t,
-            collaborators: [...t.collaborators, newCollaborator]
-          };
-        }
-        return t;
-      });
-      
-      setTrips(updatedTrips);
-      localStorage.setItem('trips', JSON.stringify(updatedTrips));
+
+    if (!userId) {
+      toast.error("Please sign in to invite people to your trip");
+      return;
     }
-    
-    toast.success(`Invitation sent to ${email}`);
+
+    try {
+      // Look up the invitee's profile by email; persist a trip_members row when found.
+      const { table } = await import("@/services/data");
+      let inviteeId: string | null = null;
+      try {
+        const { data } = await table("profiles")
+          .select("id")
+          .eq("email", email)
+          .maybeSingle();
+        inviteeId = (data as any)?.id ?? null;
+      } catch {
+        inviteeId = null;
+      }
+
+      if (inviteeId) {
+        await tripsRepo.addMember(tripId, inviteeId);
+        toast.success(`Added ${email} to the trip`);
+        loadTrips();
+      } else {
+        // Email-send itself is a demo stub.
+        toast.success(`Invitation sent to ${email}`);
+      }
+    } catch (err) {
+      console.error('[useTripManager] inviteUserToTrip failed:', err);
+      toast.error("Failed to invite user");
+    }
   };
 
   return {
     trips,
+    isLoading,
     createTrip,
     deleteTrip,
-    inviteUserToTrip
+    inviteUserToTrip,
   };
 };

--- a/src/components/places/trip/useTripMessages.ts
+++ b/src/components/places/trip/useTripMessages.ts
@@ -1,9 +1,15 @@
 
 import { useState, useEffect } from 'react';
-import { db } from '@/services/database';
-import { TripMessage } from '@/services/database/repositories/TripRepository';
 import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
+import {
+  listTripMessages,
+  sendTripMessage,
+  getCurrentUserId,
+  TripMessageRecord,
+} from "@/services/trips/tripCollabService";
+
+export type TripMessage = TripMessageRecord;
 
 export const useTripMessages = (tripId: string) => {
   const [messages, setMessages] = useState<TripMessage[]>([]);
@@ -11,62 +17,78 @@ export const useTripMessages = (tripId: string) => {
 
   useEffect(() => {
     fetchMessages();
-    subscribeToMessages();
+    const unsubscribe = subscribeToMessages();
+    return unsubscribe;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tripId]);
 
   const fetchMessages = async () => {
     try {
-      const result = await db.trips.getMessages(tripId);
-      if (result.success && result.data) {
-        setMessages(result.data);
-      } else if (result.error) {
-        console.error('Error fetching messages:', result.error);
-        toast.error('Failed to load messages');
-      }
+      const rows = await listTripMessages(tripId);
+      setMessages(rows);
     } catch (error) {
       console.error('Error fetching messages:', error);
-      toast.error('Failed to load messages');
     } finally {
       setIsLoading(false);
     }
   };
 
   const subscribeToMessages = () => {
-    const channel = supabase
-      .channel(`trip-messages-${tripId}`)
-      .on(
-        'postgres_changes',
-        {
-          event: 'INSERT',
-          schema: 'public',
-          table: 'trip_messages',
-          filter: `trip_id=eq.${tripId}`
-        },
-        (payload) => {
-          setMessages(prev => [...prev, payload.new as TripMessage]);
-        }
-      )
-      .subscribe();
+    try {
+      const channel = supabase
+        .channel(`trip-messages-${tripId}`)
+        .on(
+          'postgres_changes',
+          {
+            event: 'INSERT',
+            schema: 'public',
+            table: 'trip_messages',
+            filter: `trip_id=eq.${tripId}`
+          },
+          (payload) => {
+            setMessages(prev => {
+              const incoming = payload.new as TripMessage;
+              if (prev.some(m => m.id === incoming.id)) return prev;
+              return [...prev, incoming];
+            });
+          }
+        )
+        .subscribe();
 
-    return () => {
-      supabase.removeChannel(channel);
-    };
+      return () => {
+        supabase.removeChannel(channel);
+      };
+    } catch (err) {
+      // Realtime is optional; keep the chat working without it.
+      console.warn('[useTripMessages] realtime subscribe failed:', err);
+      return () => {};
+    }
   };
 
-  const sendMessage = async (content: string, userId: string, userName: string, userAvatar: string) => {
+  const sendMessage = async (
+    content: string,
+    userId: string,
+    userName: string,
+    userAvatar: string,
+  ) => {
+    const uid = (await getCurrentUserId()) || userId;
+    if (!uid || uid === "current-user") {
+      toast.error('Please sign in to send a message');
+      return;
+    }
     try {
-      const result = await db.trips.sendMessage({
+      const created = await sendTripMessage({
         trip_id: tripId,
         content,
-        user_id: userId,
+        user_id: uid,
         user_name: userName,
         user_avatar: userAvatar,
-        message_type: 'text'
+        message_type: 'text',
       });
-
-      if (!result.success) {
-        throw result.error || new Error('Failed to send message');
-      }
+      // Optimistically append in case realtime is unavailable.
+      setMessages(prev =>
+        prev.some(m => m.id === created.id) ? prev : [...prev, created],
+      );
     } catch (error) {
       console.error('Error sending message:', error);
       toast.error('Failed to send message');

--- a/src/components/post/CreatePostDialog.tsx
+++ b/src/components/post/CreatePostDialog.tsx
@@ -1,0 +1,214 @@
+import React, { useRef, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { ImagePlus, Loader2, X } from "lucide-react";
+import { toast } from "sonner";
+import type { Post } from "@/types";
+import { createPost, NotSignedInError } from "@/services/posts/createPost";
+
+interface CreatePostDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Optional venue/location to attach to the post. */
+  location?: { id?: string; name?: string; city?: string; state?: string };
+  /** Whether the post should be flagged as a venue post. */
+  isVenuePost?: boolean;
+  onCreated?: (post: Post) => void;
+}
+
+const CreatePostDialog: React.FC<CreatePostDialogProps> = ({
+  open,
+  onOpenChange,
+  location,
+  isVenuePost,
+  onCreated,
+}) => {
+  const [content, setContent] = useState("");
+  const [vibeTagsInput, setVibeTagsInput] = useState("");
+  const [files, setFiles] = useState<File[]>([]);
+  const [previews, setPreviews] = useState<string[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const reset = () => {
+    setContent("");
+    setVibeTagsInput("");
+    previews.forEach((url) => URL.revokeObjectURL(url));
+    setFiles([]);
+    setPreviews([]);
+  };
+
+  const handleFilesSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const picked = Array.from(e.target.files ?? []);
+    if (picked.length === 0) return;
+    setFiles((prev) => [...prev, ...picked]);
+    setPreviews((prev) => [...prev, ...picked.map((f) => URL.createObjectURL(f))]);
+    // allow re-selecting the same file later
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const removeFile = (index: number) => {
+    setFiles((prev) => prev.filter((_, i) => i !== index));
+    setPreviews((prev) => {
+      const url = prev[index];
+      if (url) URL.revokeObjectURL(url);
+      return prev.filter((_, i) => i !== index);
+    });
+  };
+
+  const close = (next: boolean) => {
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  const handleSubmit = async () => {
+    if (!content.trim() && files.length === 0) {
+      toast("Add a caption or a photo first");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const vibeTags = vibeTagsInput
+        .split(/[,#\s]+/)
+        .map((t) => t.trim())
+        .filter(Boolean);
+
+      const post = await createPost({
+        content: content.trim(),
+        files,
+        vibeTags,
+        location,
+        isVenuePost,
+      });
+      toast.success("Your vibe was posted!");
+      onCreated?.(post);
+      reset();
+      onOpenChange(false);
+    } catch (error) {
+      if (error instanceof NotSignedInError) {
+        toast("Sign in to post a vibe");
+      } else {
+        console.error("createPost failed", error);
+        toast.error("Couldn't post your vibe. Please try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={close}>
+      <DialogContent className="glass-effect max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-bold vibe-gradient-text">Create a Vibe</DialogTitle>
+          <DialogDescription>
+            {location?.name
+              ? `Share what's happening at ${location.name}.`
+              : "Share what's happening right now."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="post-content">Caption</Label>
+            <Textarea
+              id="post-content"
+              placeholder="What's the vibe?"
+              className="bg-background/50 min-h-[90px]"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+            />
+          </div>
+
+          {previews.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {previews.map((url, i) => (
+                <div key={url} className="relative h-20 w-20 overflow-hidden rounded-md">
+                  <img src={url} alt="Selected" className="h-full w-full object-cover" />
+                  <button
+                    type="button"
+                    onClick={() => removeFile(i)}
+                    className="absolute right-0 top-0 rounded-bl bg-black/60 p-1 text-white"
+                    aria-label="Remove photo"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*,video/*"
+              multiple
+              className="hidden"
+              onChange={handleFilesSelected}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <ImagePlus className="h-4 w-4 mr-2" />
+              Add photo or video
+            </Button>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="post-tags">Vibe tags</Label>
+            <Input
+              id="post-tags"
+              placeholder="e.g. cozy, lively, sunset"
+              className="bg-background/50"
+              value={vibeTagsInput}
+              onChange={(e) => setVibeTagsInput(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="flex-col sm:flex-row gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => close(false)}
+            className="sm:flex-1"
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            className="bg-gradient-to-r from-primary to-secondary sm:flex-1"
+            onClick={handleSubmit}
+            disabled={submitting}
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Posting...
+              </>
+            ) : (
+              "Post Right Now"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CreatePostDialog;

--- a/src/components/post/PostCard.tsx
+++ b/src/components/post/PostCard.tsx
@@ -10,9 +10,10 @@ import VibeTagsDisplay from "./VibeTagsDisplay";
 import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
 import { UserPlus, UserCheck } from "lucide-react";
-import { deletePost } from "@/utils/venue/postManagementUtils";
+import { deletePost, deletePostById, canCurrentUserDeletePost } from "@/utils/venue/postManagementUtils";
 import UserDropdown from "@/components/venue/post-grid-item/UserDropdown";
 import { generateVibeTags } from "@/utils/vibeTagsGenerator";
+import { getCurrentUserIdSync } from "@/services/posts/currentUser";
 
 interface PostCardProps {
   post?: Post;
@@ -206,12 +207,23 @@ const PostCard: React.FC<PostCardProps> = ({
     return null;
   }
 
-  const handleDelete = () => {
+  const currentUserId = getCurrentUserIdSync();
+  const isAuthor = canCurrentUserDeletePost(post, currentUserId);
+
+  const handleDelete = async () => {
+    // Author-owned post: persist a real delete via the data layer.
+    if (isAuthor) {
+      const ok = await deletePostById(post);
+      if (ok) {
+        setIsDeleted(true);
+        onPostDeleted?.(post.id);
+      }
+      return;
+    }
+    // Venue-management context (e.g. a venue removing a tagged post): legacy behavior.
     if (venue && deletePost(post.id, venue)) {
       setIsDeleted(true);
-      if (onPostDeleted) {
-        onPostDeleted(post.id);
-      }
+      onPostDeleted?.(post.id);
     }
   };
 
@@ -245,7 +257,7 @@ const PostCard: React.FC<PostCardProps> = ({
         timestamp={String(post.timestamp)} 
         location={post.location}
         isPinned={post.isPinned}
-        canDelete={canDelete && !isVenuePost}
+        canDelete={(canDelete || isAuthor) && !isVenuePost}
         onDelete={handleDelete}
       />
       

--- a/src/components/post/PostFooter.tsx
+++ b/src/components/post/PostFooter.tsx
@@ -3,6 +3,9 @@ import React, { useState } from "react";
 import { Heart, MessageCircle, Share, Bookmark } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Post } from "@/types";
+import { postsRepo } from "@/services/data";
+import { getCurrentUserId } from "@/services/posts/currentUser";
+import { toast } from "sonner";
 
 interface PostFooterProps {
   post: Post;
@@ -16,16 +19,62 @@ const PostFooter: React.FC<PostFooterProps> = ({
   isDetailView = false
 }) => {
   const [liked, setLiked] = useState(false);
-  const [saved, setSaved] = useState(post.saved);
+  const [saved, setSaved] = useState(Boolean(post.saved));
   const [likesCount, setLikesCount] = useState(post.likes);
+  const [likePending, setLikePending] = useState(false);
+  const [savePending, setSavePending] = useState(false);
 
-  const handleLike = () => {
-    setLiked(!liked);
-    setLikesCount(prev => liked ? prev - 1 : prev + 1);
+  const handleLike = async () => {
+    if (likePending) return;
+    const userId = await getCurrentUserId();
+    if (!userId) {
+      toast("Sign in to like posts");
+      return;
+    }
+
+    const nextLiked = !liked;
+    // Optimistic update
+    setLiked(nextLiked);
+    setLikesCount((prev) => (nextLiked ? prev + 1 : Math.max(0, prev - 1)));
+    setLikePending(true);
+
+    try {
+      await postsRepo.toggleLike(post.id, userId, nextLiked);
+    } catch (error) {
+      // Revert on error
+      setLiked(!nextLiked);
+      setLikesCount((prev) => (nextLiked ? Math.max(0, prev - 1) : prev + 1));
+      toast.error("Couldn't update your like. Please try again.");
+      console.error("toggleLike failed", error);
+    } finally {
+      setLikePending(false);
+    }
   };
 
-  const handleSave = () => {
-    setSaved(!saved);
+  const handleSave = async () => {
+    if (savePending) return;
+    const userId = await getCurrentUserId();
+    if (!userId) {
+      toast("Sign in to save posts");
+      return;
+    }
+
+    const nextSaved = !saved;
+    // Optimistic update
+    setSaved(nextSaved);
+    setSavePending(true);
+
+    try {
+      await postsRepo.toggleSave(post.id, userId, nextSaved);
+      toast(nextSaved ? "Saved to Pinned Vibes" : "Removed from Pinned Vibes");
+    } catch (error) {
+      // Revert on error
+      setSaved(!nextSaved);
+      toast.error("Couldn't update your save. Please try again.");
+      console.error("toggleSave failed", error);
+    } finally {
+      setSavePending(false);
+    }
   };
 
   return (
@@ -36,6 +85,7 @@ const PostFooter: React.FC<PostFooterProps> = ({
               variant="ghost"
               size="sm"
               onClick={handleLike}
+              disabled={likePending}
               className={`flex items-center gap-2 h-10 ${liked ? 'text-red-500' : ''}`}
             >
               <Heart className={`h-4 w-4 ${liked ? 'fill-current' : ''}`} />
@@ -62,12 +112,13 @@ const PostFooter: React.FC<PostFooterProps> = ({
             variant="ghost"
             size="sm"
             onClick={handleSave}
+            disabled={savePending}
             className={`h-10 ${saved ? 'text-blue-500' : ''}`}
           >
           <Bookmark className={`h-4 w-4 ${saved ? 'fill-current' : ''}`} />
         </Button>
       </div>
-      
+
       {post.vibeTags && post.vibeTags.length > 0 && (
         <div className="flex flex-wrap gap-2 mt-3">
           {post.vibeTags.map((tag, index) => (

--- a/src/components/user/UserProfileHeader.tsx
+++ b/src/components/user/UserProfileHeader.tsx
@@ -3,21 +3,36 @@ import React from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Share, UserPlus, MapPin, Calendar, Users } from "lucide-react";
+import { Share, UserPlus, UserCheck, MapPin, Calendar, Users } from "lucide-react";
 import { User } from '@/types';
 
 interface UserProfileHeaderProps {
   user: User;
-  onFollow?: (userToFollow: string) => Promise<boolean>;
-  onUnfollow?: (userToUnfollow: string) => Promise<boolean>;
+  onFollow?: () => Promise<boolean>;
+  onUnfollow?: () => Promise<boolean>;
   onUpdateBio?: (newBio: string) => Promise<boolean>;
   onBlock?: (userToBlock: string) => Promise<boolean>;
   onReport?: (userToReport: string, reason: string) => Promise<boolean>;
   isPrivate?: boolean;
+  isFollowing?: boolean;
+  isOwnProfile?: boolean;
   getUserBio?: () => string;
 }
 
-const UserProfileHeader: React.FC<UserProfileHeaderProps> = ({ user }) => {
+const UserProfileHeader: React.FC<UserProfileHeaderProps> = ({
+  user,
+  onFollow,
+  onUnfollow,
+  isFollowing = false,
+  isOwnProfile = false,
+}) => {
+  const handleFollowClick = () => {
+    if (isFollowing) {
+      onUnfollow?.();
+    } else {
+      onFollow?.();
+    }
+  };
   const joinedDate = new Date(user.createdAt || '').toLocaleDateString('en-US', { 
     month: 'short', 
     year: 'numeric' 
@@ -32,10 +47,26 @@ const UserProfileHeader: React.FC<UserProfileHeaderProps> = ({ user }) => {
             <Share className="h-4 w-4 mr-1" />
             Share
           </Button>
-          <Button size="sm" className="bg-white text-black hover:bg-gray-100">
-            <UserPlus className="h-4 w-4 mr-1" />
-            Follow
-          </Button>
+          {!isOwnProfile && (
+            <Button
+              size="sm"
+              onClick={handleFollowClick}
+              variant={isFollowing ? "outline" : "default"}
+              className={isFollowing ? "bg-background/80 backdrop-blur-sm" : "bg-white text-black hover:bg-gray-100"}
+            >
+              {isFollowing ? (
+                <>
+                  <UserCheck className="h-4 w-4 mr-1" />
+                  Following
+                </>
+              ) : (
+                <>
+                  <UserPlus className="h-4 w-4 mr-1" />
+                  Follow
+                </>
+              )}
+            </Button>
+          )}
         </div>
       </div>
       

--- a/src/components/venue/ExternalReviewAnalysis.tsx
+++ b/src/components/venue/ExternalReviewAnalysis.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { MessageSquare, ExternalLink, Loader2, Globe, TrendingUp } from "lucide-react";
 import { useUserSubscription } from "@/hooks/useUserSubscription";
-import { supabase } from "@/integrations/supabase/client";
+import { invokeEdgeWithFallback } from "@/services/edge/invokeEdge";
 import VernonReviewChat from './VernonReviewChat';
 
 interface ExternalReviewAnalysisProps {
@@ -28,6 +28,33 @@ interface ReviewAnalysisData {
   };
   analyzedAt: string;
 }
+
+/**
+ * Deterministic mock insight used when the review-sentiment-analyzer edge function is
+ * unavailable (e.g. no API keys). Keeps the venue insights surface populated in the demo.
+ */
+const buildMockAnalysis = (url: string, venueName: string): ReviewAnalysisData => {
+  let domain = "reviews";
+  try {
+    domain = new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    /* keep default */
+  }
+  return {
+    url,
+    domain,
+    platform: domain.split(".")[0] || "web",
+    summary: `Reviewers describe ${venueName} as a welcoming spot with great atmosphere and friendly staff. Most visitors highlight the quality of the experience, with occasional notes about wait times during peak hours.`,
+    reviewCount: 128,
+    overallSentiment: 0.82,
+    themes: {
+      positive: ["great atmosphere", "friendly staff", "good value"],
+      negative: ["busy on weekends", "limited parking"],
+      neutral: ["central location", "casual setting"],
+    },
+    analyzedAt: new Date().toISOString(),
+  };
+};
 
 const ExternalReviewAnalysis: React.FC<ExternalReviewAnalysisProps> = ({
   venueId,
@@ -62,21 +89,16 @@ const ExternalReviewAnalysis: React.FC<ExternalReviewAnalysisProps> = ({
     try {
       // Validate URL
       new URL(url);
-      
-      const { data, error: functionError } = await supabase.functions.invoke('parse-venue-reviews', {
-        body: {
-          url: url.trim(),
-          venueId
-        }
-      });
 
-      if (functionError) throw functionError;
+      // Route venue review sentiment through the edge helper, falling back to a local
+      // mock insight so the feature works with zero API keys configured.
+      const analysis = await invokeEdgeWithFallback<ReviewAnalysisData>(
+        'review-sentiment-analyzer',
+        { url: url.trim(), venueId, venueName },
+        () => buildMockAnalysis(url.trim(), venueName)
+      );
 
-      if (data.success) {
-        setAnalysisData(data.data);
-      } else {
-        throw new Error('Failed to analyze reviews');
-      }
+      setAnalysisData(analysis);
     } catch (error) {
       console.error('Error analyzing reviews:', error);
       setError(error instanceof Error ? error.message : 'Invalid URL or analysis failed');

--- a/src/components/venue/WaitTimeDisplay.tsx
+++ b/src/components/venue/WaitTimeDisplay.tsx
@@ -104,10 +104,11 @@ const WaitTimeDisplay = ({ venueId, showLastUpdated = true, className = "" }: Wa
     <div className={`flex items-center gap-2 text-sm ${className}`}>
       <Clock className="h-4 w-4 text-amber-500" />
       <span className="font-medium">
-        {waitTimeData.wait_minutes === 0 
-          ? "No wait time" 
+        {waitTimeData.wait_minutes === 0
+          ? "No wait time"
           : `~${waitTimeData.wait_minutes} min wait`}
       </span>
+      <span className="text-xs text-muted-foreground ml-1">(estimated)</span>
       {showLastUpdated && (
         <span className="text-xs text-muted-foreground ml-1">
           Updated {timeAgo}

--- a/src/hooks/explore/useLocationData.ts
+++ b/src/hooks/explore/useLocationData.ts
@@ -1,32 +1,55 @@
 
 import { useState, useEffect } from "react";
 import { Location } from "@/types";
-import { mockLocations } from "@/mock/data";
 import { EventItem } from "@/components/venue/events/types";
 import { generateMusicEvents, generateComedyEvents, getComedyEventsForCity } from "@/services/search/eventService";
 import { generateMockLocationsForCity, generateLocalNightlifeVenues } from "@/utils/explore/locationGenerators";
 import { getAdditionalTags } from "@/utils/explore/mockGenerators";
+import { locationsRepo } from "@/services/data";
 
 export const useLocationData = (
   searchedCity: string,
   searchedState: string,
   dateRange?: { from: Date; to?: Date }
 ) => {
-  const [filteredLocations, setFilteredLocations] = useState<Location[]>(mockLocations);
+  const [filteredLocations, setFilteredLocations] = useState<Location[]>([]);
   const [locationTags, setLocationTags] = useState<Record<string, string[]>>({});
   const [musicEvents, setMusicEvents] = useState<EventItem[]>([]);
   const [comedyEvents, setComedyEvents] = useState<EventItem[]>([]);
   const [nightlifeVenues, setNightlifeVenues] = useState<Location[]>([]);
-  
-  // Initialize location tags
+
+  // Load the venue list from the data layer (Supabase with mock fallback). A searched
+  // city uses byCity, otherwise we surface a default nearby set so the list is populated.
   useEffect(() => {
-    const tagsMap: Record<string, string[]> = {};
-    mockLocations.forEach(location => {
-      tagsMap[location.id] = getAdditionalTags(location);
-    });
-    setLocationTags(tagsMap);
-  }, []);
-  
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const results = searchedCity && searchedCity.trim()
+          ? await locationsRepo.byCity(searchedCity.trim())
+          : await locationsRepo.nearby(0, 0, 50);
+
+        if (cancelled) return;
+        setFilteredLocations(results);
+
+        // Build the per-location tag map from the loaded set.
+        const tagsMap: Record<string, string[]> = {};
+        results.forEach((location) => {
+          tagsMap[location.id] = getAdditionalTags(location);
+        });
+        setLocationTags(tagsMap);
+      } catch (err) {
+        console.error("Error loading explore locations:", err);
+        if (!cancelled) setFilteredLocations([]);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [searchedCity]);
+
   // Update events when city or date range changes
   useEffect(() => {
     if (searchedCity) {

--- a/src/hooks/useCheckIn.ts
+++ b/src/hooks/useCheckIn.ts
@@ -1,8 +1,10 @@
 
 import { useState, useEffect } from "react";
 import { toast } from "@/hooks/use-toast";
+import { toast as sonnerToast } from "sonner";
 import { Location } from "@/types";
 import { calculateDistance } from "@/components/map/common/DistanceCalculator";
+import { checkInAndPost, NotSignedInError } from "@/services/posts/createPost";
 
 export function useCheckIn(venue: Location) {
   const [isOpen, setIsOpen] = useState(false);
@@ -59,15 +61,43 @@ export function useCheckIn(venue: Location) {
     }
   };
 
-  const confirmCheckIn = (pointsEarned: number) => {
-    setIsCheckedIn(true);
-    setIsOpen(false);
-    
-    toast({
-      title: "Checked in successfully!",
-      description: `You earned ${pointsEarned} points at ${venue.name}`,
-      variant: "default"
-    });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const confirmCheckIn = async (pointsEarned: number, photo?: File | null) => {
+    setIsSubmitting(true);
+    try {
+      // Persist a check_ins row and a post for the venue via the data layer.
+      await checkInAndPost({
+        content: `Checked in at ${venue.name}`,
+        files: photo ? [photo] : [],
+        note: `Checked in at ${venue.name}`,
+        location: {
+          id: venue.id,
+          name: venue.name,
+          city: venue.city,
+          state: venue.state,
+        },
+        isVenuePost: false,
+      });
+
+      setIsCheckedIn(true);
+      setIsOpen(false);
+
+      toast({
+        title: "Checked in successfully!",
+        description: `You earned ${pointsEarned} points at ${venue.name}`,
+        variant: "default"
+      });
+    } catch (error) {
+      if (error instanceof NotSignedInError) {
+        sonnerToast("Sign in to check in");
+      } else {
+        console.error("Check-in failed", error);
+        sonnerToast.error("Couldn't complete your check-in. Please try again.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return {
@@ -78,6 +108,7 @@ export function useCheckIn(venue: Location) {
     isInRange,
     distance,
     userLocation,
+    isSubmitting,
     handleCheckInClick,
     confirmCheckIn
   };

--- a/src/hooks/useEnhancedGooglePlaces.ts
+++ b/src/hooks/useEnhancedGooglePlaces.ts
@@ -1,6 +1,6 @@
 
 import { useState, useCallback } from 'react';
-import { supabase } from '@/integrations/supabase/client';
+import { invokeEdge } from '@/services/edge/invokeEdge';
 
 export interface EnhancedPlace {
   place_id: string;
@@ -65,19 +65,17 @@ export const useEnhancedGooglePlaces = () => {
     try {
       console.log('Enhanced search request:', { query, options });
 
-      const { data, error: functionError } = await supabase.functions.invoke('google-places', {
-        body: {
-          query,
-          searchType: options.searchType,
-          location: options.location,
-          radius: options.radius,
-          type: options.type,
-          fields: [
-            'place_id', 'name', 'formatted_address', 'geometry', 'types',
-            'rating', 'price_level', 'photos', 'opening_hours', 'business_status',
-            'website', 'formatted_phone_number'
-          ]
-        }
+      const { data, error: functionError } = await invokeEdge<SearchResult>('google-places', {
+        query,
+        searchType: options.searchType,
+        location: options.location,
+        radius: options.radius,
+        type: options.type,
+        fields: [
+          'place_id', 'name', 'formatted_address', 'geometry', 'types',
+          'rating', 'price_level', 'photos', 'opening_hours', 'business_status',
+          'website', 'formatted_phone_number'
+        ]
       });
 
       if (functionError) {
@@ -114,8 +112,9 @@ export const useEnhancedGooglePlaces = () => {
     setError(null);
 
     try {
-      const { data, error: functionError } = await supabase.functions.invoke('google-places', {
-        body: {
+      const { data, error: functionError } = await invokeEdge<{ result?: EnhancedPlace }>(
+        'google-places',
+        {
           placeId,
           fields: [
             'place_id', 'name', 'formatted_address', 'geometry', 'types',
@@ -123,7 +122,7 @@ export const useEnhancedGooglePlaces = () => {
             'website', 'formatted_phone_number', 'reviews'
           ]
         }
-      });
+      );
 
       if (functionError) {
         console.error('Error getting place details:', functionError);

--- a/src/hooks/useGooglePlacesSearch.ts
+++ b/src/hooks/useGooglePlacesSearch.ts
@@ -1,6 +1,6 @@
 
 import { useState, useCallback } from 'react';
-import { supabase } from '@/integrations/supabase/client';
+import { invokeEdge } from '@/services/edge/invokeEdge';
 
 export const useGooglePlacesSearch = (location: string) => {
   const [suggestions, setSuggestions] = useState<google.maps.places.PlaceResult[]>([]);
@@ -17,13 +17,14 @@ export const useGooglePlacesSearch = (location: string) => {
     setLoading(true);
     try {
       const searchQuery = location ? `${query} in ${location}` : query;
-      
-      const { data, error } = await supabase.functions.invoke('google-places', {
-        body: {
+
+      const { data, error } = await invokeEdge<{ results?: google.maps.places.PlaceResult[] }>(
+        'google-places',
+        {
           query: searchQuery,
           type: 'establishment'
         }
-      });
+      );
 
       if (error) {
         console.error('Error fetching venues:', error);

--- a/src/hooks/useNearbyLocations.ts
+++ b/src/hooks/useNearbyLocations.ts
@@ -1,15 +1,19 @@
 
 import { useState, useEffect } from 'react';
 import { Location, Coordinates } from '@/types';
-import { mockCities } from '@/data/mockCities';
+import { locationsRepo } from '@/services/data';
 
+/**
+ * Nearby venues sourced through `locationsRepo.nearby` (Supabase with mock fallback).
+ * A searched city is resolved via `locationsRepo.byCity`. Works with zero API keys.
+ */
 export const useNearbyLocations = () => {
   const [nearbyLocations, setNearbyLocations] = useState<Location[]>([]);
   const [userLocation, setUserLocation] = useState<Coordinates | null>(null);
   const [loading, setLoading] = useState(false);
   const [searchedCity, setSearchedCity] = useState<string>("");
   const [userAddressLocation, setUserAddressLocation] = useState<Coordinates | null>(null);
-  
+
   useEffect(() => {
     // Try to get user's current location
     if (navigator.geolocation) {
@@ -30,33 +34,35 @@ export const useNearbyLocations = () => {
       );
     }
   }, []);
-  
+
   useEffect(() => {
-    const effectiveLocation = userAddressLocation || userLocation;
-    
-    if (!effectiveLocation) {
-      // Return all locations from mock cities if no user location
-      const allLocations = mockCities.flatMap(city => city.venues);
-      setNearbyLocations(allLocations.slice(0, 20)); // Limit to 20 for performance
-      return;
-    }
-    
-    // Calculate distance and find nearby locations
-    const allLocations = mockCities.flatMap(city => city.venues);
-    const locationsWithDistance = allLocations.map(location => ({
-      ...location,
-      distance: calculateDistance(effectiveLocation.lat, effectiveLocation.lng, location.lat, location.lng)
-    }));
-    
-    // Sort by distance and take closest 20
-    const nearby = locationsWithDistance
-      .sort((a, b) => a.distance - b.distance)
-      .slice(0, 20)
-      .map(({ distance, ...location }) => location);
-    
-    setNearbyLocations(nearby);
-  }, [userLocation, userAddressLocation]);
-  
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      try {
+        let results: Location[];
+        if (searchedCity && searchedCity.trim()) {
+          results = await locationsRepo.byCity(searchedCity.trim());
+        } else {
+          const effective = userAddressLocation || userLocation;
+          results = await locationsRepo.nearby(effective?.lat ?? 0, effective?.lng ?? 0);
+        }
+        if (!cancelled) setNearbyLocations(results.slice(0, 20));
+      } catch (err) {
+        console.error('Error loading nearby locations:', err);
+        if (!cancelled) setNearbyLocations([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [userLocation, userAddressLocation, searchedCity]);
+
   return {
     userLocation,
     nearbyLocations,
@@ -67,17 +73,3 @@ export const useNearbyLocations = () => {
     setUserAddressLocation
   };
 };
-
-// Helper function to calculate distance between two coordinates
-function calculateDistance(lat1: number, lng1: number, lat2: number, lng2: number): number {
-  const R = 6371; // Radius of the Earth in kilometers
-  const dLat = (lat2 - lat1) * Math.PI / 180;
-  const dLng = (lng2 - lng1) * Math.PI / 180;
-  const a = 
-    Math.sin(dLat/2) * Math.sin(dLat/2) +
-    Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) * 
-    Math.sin(dLng/2) * Math.sin(dLng/2);
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
-  const distance = R * c;
-  return distance;
-}

--- a/src/hooks/usePostDeletion.ts
+++ b/src/hooks/usePostDeletion.ts
@@ -1,17 +1,32 @@
 
 import { useState } from 'react';
+import { Post } from '@/types';
+import { deletePostById } from '@/utils/venue/postManagementUtils';
 
 export const usePostDeletion = () => {
-  // State to track deleted posts
+  // State to track deleted posts (used to optimistically hide them in lists/feeds)
   const [deletedPostIds, setDeletedPostIds] = useState<string[]>([]);
-  
-  // Handle post deletion
+
+  // Mark a post as deleted locally (after a successful remove, or to hide optimistically)
   const handlePostDeleted = (postId: string) => {
-    setDeletedPostIds(prev => [...prev, postId]);
+    setDeletedPostIds(prev => (prev.includes(postId) ? prev : [...prev, postId]));
   };
-  
+
+  /**
+   * Persist a delete via the data layer (author-only) and, on success, hide the post.
+   * Returns whether the deletion succeeded.
+   */
+  const deletePost = async (post: Post): Promise<boolean> => {
+    const ok = await deletePostById(post);
+    if (ok) {
+      handlePostDeleted(post.id);
+    }
+    return ok;
+  };
+
   return {
     deletedPostIds,
-    handlePostDeleted
+    handlePostDeleted,
+    deletePost,
   };
 };

--- a/src/hooks/useSimplifiedNearbyLocations.ts
+++ b/src/hooks/useSimplifiedNearbyLocations.ts
@@ -1,24 +1,29 @@
 import { useState, useEffect } from 'react';
 import { Location } from '@/types';
-import { Coordinates, UserLocation, toCoordinates } from '@/types/coordinates';
+import { Coordinates } from '@/types/coordinates';
+import { locationsRepo } from '@/services/data';
 
+/**
+ * Provides nearby venues for the Explore map. Data is sourced through `locationsRepo`
+ * (Supabase with automatic mock fallback): a searched city uses `byCity`, otherwise we
+ * fall back to `nearby` around the user's coordinates. Works with zero API keys.
+ */
 export const useSimplifiedNearbyLocations = () => {
   const [nearbyLocations, setNearbyLocations] = useState<Location[]>([]);
   const [userLocation, setUserLocation] = useState<Coordinates | null>(null);
   const [loading, setLoading] = useState(false);
   const [searchedCity, setSearchedCity] = useState<string>("");
   const [userAddressLocation, setUserAddressLocation] = useState<[number, number] | null>(null);
-  
+
   useEffect(() => {
     if (navigator.geolocation) {
       setLoading(true);
       navigator.geolocation.getCurrentPosition(
         (position) => {
-          const coords: Coordinates = {
+          setUserLocation({
             lat: position.coords.latitude,
             lng: position.coords.longitude
-          };
-          setUserLocation(coords);
+          });
           setLoading(false);
         },
         (error) => {
@@ -28,13 +33,39 @@ export const useSimplifiedNearbyLocations = () => {
       );
     }
   }, []);
-  
-  // For now, we'll keep nearby locations empty since we're removing mock data
-  // This will be populated later with real Google Places API data
+
+  // Load venues whenever the searched city, user location, or address changes.
   useEffect(() => {
-    setNearbyLocations([]);
-  }, [userLocation, userAddressLocation]);
-  
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      try {
+        let results: Location[];
+        if (searchedCity && searchedCity.trim()) {
+          results = await locationsRepo.byCity(searchedCity.trim());
+        } else {
+          const lat = userAddressLocation ? userAddressLocation[1] : userLocation?.lat ?? 0;
+          const lng = userAddressLocation ? userAddressLocation[0] : userLocation?.lng ?? 0;
+          results = await locationsRepo.nearby(lat, lng);
+        }
+        if (!cancelled) {
+          setNearbyLocations(results.filter((l) => l.lat && l.lng));
+        }
+      } catch (err) {
+        console.error('Error loading nearby locations:', err);
+        if (!cancelled) setNearbyLocations([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [searchedCity, userLocation, userAddressLocation]);
+
   return {
     userLocation,
     nearbyLocations,

--- a/src/hooks/useSupabaseAuth.ts
+++ b/src/hooks/useSupabaseAuth.ts
@@ -1,0 +1,22 @@
+import { useContext } from "react";
+import { SupabaseAuthContext, type SupabaseAuthContextValue } from "@/auth/SupabaseAuthProvider";
+
+/**
+ * Access the Supabase auth session/user and auth actions.
+ *
+ * Replaces the previous Auth0 hook. Provides:
+ *  - session / user (Supabase auth types)
+ *  - isAuthenticated / isLoading
+ *  - signIn (email + password), signUp, signInWithGoogle, signInWithMagicLink, signOut
+ *
+ * Must be used inside <SupabaseAuthProvider> (wired in App.tsx).
+ */
+export const useSupabaseAuth = (): SupabaseAuthContextValue => {
+  const ctx = useContext(SupabaseAuthContext);
+  if (!ctx) {
+    throw new Error("useSupabaseAuth must be used within a SupabaseAuthProvider");
+  }
+  return ctx;
+};
+
+export default useSupabaseAuth;

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,12 +1,21 @@
 
-import { useState, useEffect } from 'react';
-import { UserProfileData, UserProfileStats, User, Post, Location, Comment } from '@/types';
+import { useState, useEffect, useCallback } from 'react';
+import { UserProfileStats, User, Post, Location, Comment } from '@/types';
 import { mockUsers, getUserById, getUserByUsername } from '@/mock/users';
-import { mockPosts } from '@/mock/posts';
 import { mockComments } from '@/mock/comments';
 import { mockLocations } from '@/mock/locations';
+import { profilesRepo, postsRepo } from '@/services/data';
+import { followService } from '@/services/social/followService';
+import { useUserStore } from '@/store/userStore';
 
+/**
+ * Loads a user's public profile (by username, falling back to id) and their posts
+ * through the data layer (Supabase with mock fallback). Follow/unfollow writes go
+ * through followService and require an authenticated session; when signed out they
+ * resolve false so callers can prompt sign-in.
+ */
 export const useUserProfile = (userIdOrUsername?: string) => {
+  const { user: currentUser, isAuthenticated } = useUserStore();
   const [profile, setProfile] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -14,6 +23,7 @@ export const useUserProfile = (userIdOrUsername?: string) => {
   const [followedVenues, setFollowedVenues] = useState<Location[]>([]);
   const [visitedPlaces, setVisitedPlaces] = useState<Location[]>([]);
   const [wantToVisitPlaces, setWantToVisitPlaces] = useState<Location[]>([]);
+  const [isFollowing, setIsFollowing] = useState(false);
   const [stats, setStats] = useState<UserProfileStats>({
     posts: 0,
     followers: 0,
@@ -22,95 +32,127 @@ export const useUserProfile = (userIdOrUsername?: string) => {
   });
 
   useEffect(() => {
-    if (userIdOrUsername) {
+    if (!userIdOrUsername) return;
+    let active = true;
+
+    const load = async () => {
       setLoading(true);
-      
-      setTimeout(() => {
-        // Try to find user by ID first, then by username
-        let user = getUserById(userIdOrUsername);
+      try {
+        // Resolve by username first, then by id.
+        let user = await profilesRepo.getByUsername(userIdOrUsername);
         if (!user) {
-          user = getUserByUsername(userIdOrUsername);
+          user = await profilesRepo.getById(userIdOrUsername);
         }
-        
+
+        if (!active) return;
+
         if (user) {
           setProfile(user);
-          const posts = mockPosts.filter(p => p.user.id === user.id);
+          const posts = await postsRepo.getByUser(user.id);
+          if (!active) return;
           setUserPosts(posts);
+
+          const [followers, following] = await Promise.all([
+            followService.followerCount(user.id),
+            followService.followingCount(user.id),
+          ]);
+          if (!active) return;
+
           setStats({
             posts: posts.length,
-            followers: user.followers || 0,
-            following: user.following || 0,
-            likes: posts.reduce((sum, post) => sum + post.likes, 0)
+            followers: followers || user.followers || 0,
+            following: following || user.following || 0,
+            likes: posts.reduce((sum, post) => sum + (post.likes || 0), 0),
           });
+
+          // Places sections remain mock-backed (owned by other streams).
           setFollowedVenues(mockLocations.slice(0, 3));
           setVisitedPlaces(mockLocations.slice(0, 5));
           setWantToVisitPlaces(mockLocations.slice(5, 8));
           setError(null);
+
+          if (currentUser?.id && currentUser.id !== user.id) {
+            const following = await followService.isFollowing(currentUser.id, user.id);
+            if (active) setIsFollowing(following);
+          }
         } else {
           setError('User not found');
           setProfile(null);
         }
-        setLoading(false);
-      }, 500);
-    }
-  }, [userIdOrUsername]);
-
-  const followUser = async (userToFollow: string): Promise<boolean> => {
-    return true;
-  };
-
-  const unfollowUser = async (userToUnfollow: string): Promise<boolean> => {
-    return true;
-  };
-
-  const getFollowStatus = (userId: string): boolean => {
-    return false;
-  };
-
-  const getMutualFollowers = (userId: string): User[] => {
-    return mockUsers.slice(0, 2);
-  };
-
-  const getUserPosts = (userId: string): Post[] => {
-    return mockPosts.filter(p => p.user.id === userId);
-  };
-
-  const getUserStats = (userId: string): UserProfileStats => {
-    const posts = getUserPosts(userId);
-    const user = mockUsers.find(u => u.id === userId);
-    return {
-      posts: posts.length,
-      followers: user?.followers || 0,
-      following: user?.following || 0,
-      likes: posts.reduce((sum, post) => sum + post.likes, 0)
+      } catch (err) {
+        if (active) {
+          console.warn('[useUserProfile] load failed:', err);
+          setError('User not found');
+          setProfile(null);
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
     };
-  };
 
-  const getPostComments = (postId: string): Comment[] => {
-    return mockComments.filter(c => c.postId === postId);
-  };
+    load();
+    return () => {
+      active = false;
+    };
+  }, [userIdOrUsername, currentUser?.id]);
+
+  const followUser = useCallback(
+    async (): Promise<boolean> => {
+      if (!isAuthenticated || !currentUser?.id || !profile?.id) return false;
+      try {
+        await followService.follow(currentUser.id, profile.id);
+        setIsFollowing(true);
+        setStats((s) => ({ ...s, followers: s.followers + 1 }));
+        return true;
+      } catch (err) {
+        console.warn('[useUserProfile] follow failed:', err);
+        return false;
+      }
+    },
+    [isAuthenticated, currentUser?.id, profile?.id],
+  );
+
+  const unfollowUser = useCallback(
+    async (): Promise<boolean> => {
+      if (!isAuthenticated || !currentUser?.id || !profile?.id) return false;
+      try {
+        await followService.unfollow(currentUser.id, profile.id);
+        setIsFollowing(false);
+        setStats((s) => ({ ...s, followers: Math.max(0, s.followers - 1) }));
+        return true;
+      } catch (err) {
+        console.warn('[useUserProfile] unfollow failed:', err);
+        return false;
+      }
+    },
+    [isAuthenticated, currentUser?.id, profile?.id],
+  );
+
+  const getFollowStatus = (): boolean => isFollowing;
+
+  const getMutualFollowers = (): User[] => mockUsers.slice(0, 2) as unknown as User[];
+
+  const getUserStats = (): UserProfileStats => stats;
+
+  const getPostComments = (postId: string): Comment[] =>
+    mockComments.filter((c) => c.postId === postId);
 
   const updateBio = async (bio: string): Promise<boolean> => {
-    return true;
+    if (!isAuthenticated || !currentUser?.id || currentUser.id !== profile?.id) return false;
+    try {
+      await profilesRepo.update(currentUser.id, { bio });
+      setProfile((p) => (p ? { ...p, bio } : p));
+      return true;
+    } catch (err) {
+      console.warn('[useUserProfile] updateBio failed:', err);
+      return false;
+    }
   };
 
-  const blockUser = async (userId: string): Promise<boolean> => {
-    return true;
-  };
+  const blockUser = async (): Promise<boolean> => true;
+  const reportUser = async (): Promise<boolean> => true;
 
-  const reportUser = async (userId: string, reason: string): Promise<boolean> => {
-    return true;
-  };
-
-  const getUserBio = (userId: string): string => {
-    const user = mockUsers.find(u => u.id === userId);
-    return user?.bio || '';
-  };
-
-  const isPrivateProfile = (userId: string): boolean => {
-    const user = mockUsers.find(u => u.id === userId);
-    return user?.isPrivate || false;
-  };
+  const getUserBio = (): string => profile?.bio || '';
 
   return {
     profile,
@@ -121,11 +163,11 @@ export const useUserProfile = (userIdOrUsername?: string) => {
     visitedPlaces,
     wantToVisitPlaces,
     stats,
+    isFollowing,
     followUser,
     unfollowUser,
     getFollowStatus,
     getMutualFollowers,
-    getUserPosts,
     getUserStats,
     getPostComments,
     setStats,
@@ -133,6 +175,6 @@ export const useUserProfile = (userIdOrUsername?: string) => {
     blockUser,
     reportUser,
     getUserBio,
-    isPrivateProfile: profile?.isPrivate || false
+    isPrivateProfile: profile?.isPrivate || false,
   };
 };

--- a/src/hooks/useUserSubscription.ts
+++ b/src/hooks/useUserSubscription.ts
@@ -1,8 +1,10 @@
 
 import { useState, useEffect } from 'react';
 import { UserSubscription, UserSubscriptionTier, TIER_FEATURES } from '@/types/subscription';
+import { useUserStore } from '@/store/userStore';
 
 export const useUserSubscription = () => {
+  const { user } = useUserStore();
   const [subscription, setSubscription] = useState<UserSubscription>({
     tier: 'free',
     isActive: true,
@@ -10,7 +12,18 @@ export const useUserSubscription = () => {
   });
 
   useEffect(() => {
-    // Load subscription from localStorage or API
+    // Prefer the authenticated profile's subscription tier (synced from Supabase),
+    // then fall back to any locally-persisted subscription for the demo.
+    const storeTier = user?.subscription as UserSubscriptionTier | undefined;
+    if (storeTier && TIER_FEATURES[storeTier]) {
+      setSubscription({
+        tier: storeTier,
+        isActive: true,
+        features: TIER_FEATURES[storeTier],
+      });
+      return;
+    }
+
     const savedSubscription = localStorage.getItem('userSubscription');
     if (savedSubscription) {
       const parsed = JSON.parse(savedSubscription);
@@ -19,7 +32,7 @@ export const useUserSubscription = () => {
         features: TIER_FEATURES[parsed.tier as UserSubscriptionTier]
       });
     }
-  }, []);
+  }, [user?.subscription]);
 
   const updateSubscriptionTier = (newTier: UserSubscriptionTier) => {
     const updatedSubscription: UserSubscription = {

--- a/src/pages/Explore.tsx
+++ b/src/pages/Explore.tsx
@@ -1,5 +1,7 @@
 
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { toast } from "sonner";
 import Header from "@/components/Header";
 import CameraButton from "@/components/CameraButton";
 import NearbyVibesMap from "@/components/NearbyVibesMap";
@@ -10,14 +12,16 @@ import ExploreSidebar from "@/components/explore/ExploreSidebar";
 import { useMapSync } from "@/hooks/useMapSync";
 import { Location } from "@/types";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { locationsRepo } from "@/services/data";
 
 const Explore = () => {
   const isMobile = useIsMobile();
+  const { city: cityParam } = useParams<{ city?: string }>();
   const [searchQuery, setSearchQuery] = useState("");
-  const [location, setLocation] = useState("");
-  
+  const [location, setLocation] = useState(cityParam ?? "");
+
   const { mapState, updateMapCenter, updateRealPlaces, zoomToPlace } = useMapSync();
-  
+
   const {
     activeTab,
     searchedCity,
@@ -44,6 +48,29 @@ const Explore = () => {
     setShowDateFilter
   } = useExploreState();
 
+  // When arriving on /explore/:city, load that city's venues onto the map from the
+  // data layer (Supabase with mock fallback) so the page is populated immediately.
+  useEffect(() => {
+    if (!cityParam) return;
+    let cancelled = false;
+    setLocation(cityParam);
+    locationsRepo
+      .byCity(cityParam)
+      .then((results) => {
+        if (cancelled) return;
+        const withCoords = results.filter((l) => l.lat && l.lng);
+        if (withCoords.length > 0) {
+          updateRealPlaces(withCoords);
+          updateMapCenter(withCoords[0]);
+        }
+      })
+      .catch((err) => console.error("Error loading city venues:", err));
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cityParam]);
+
   const handlePlaceSelect = useCallback((place: Location) => {
     if (place.lat && place.lng) {
       updateMapCenter(place);
@@ -51,12 +78,18 @@ const Explore = () => {
       if (place.type === 'city') {
         const cityName = place.name || '';
         setLocation(cityName);
-        // Note: For now, we're not populating venues since we removed mock data
-        // This will be updated when real venue data is integrated
+        // Populate venues for the selected city from the data layer.
+        locationsRepo
+          .byCity(cityName)
+          .then((results) => {
+            const withCoords = results.filter((l) => l.lat && l.lng);
+            if (withCoords.length > 0) updateRealPlaces(withCoords);
+          })
+          .catch((err) => console.error("Error loading city venues:", err));
       } else {
         updateRealPlaces([place]);
       }
-      
+
       zoomToPlace(place);
     }
   }, [updateMapCenter, updateRealPlaces, setLocation, zoomToPlace]);
@@ -68,17 +101,41 @@ const Explore = () => {
       if (place.city && !location) {
         setLocation(place.city);
       }
-      
+
       updateRealPlaces([place]);
       zoomToPlace(place);
     }
   }, [updateMapCenter, updateRealPlaces, location, setLocation, zoomToPlace]);
+
+  // Natural-language / free-text search. Routes through locationsRepo.search which tries
+  // the google-places edge function first and transparently falls back to mock venues.
+  const handleSmartSearch = useCallback(async (query: string) => {
+    const q = query.trim();
+    if (!q) return;
+    try {
+      const results = await locationsRepo.search(q);
+      const withCoords = results.filter((l) => l.lat && l.lng);
+      if (withCoords.length > 0) {
+        updateRealPlaces(withCoords);
+        updateMapCenter(withCoords[0]);
+        zoomToPlace(withCoords[0]);
+        toast.success(`Found ${results.length} place${results.length === 1 ? "" : "s"} for "${q}"`);
+      } else {
+        toast(`No mappable results for "${q}"`);
+      }
+    } catch (err) {
+      console.error("Search error:", err);
+      toast.error("Search failed. Please try again.");
+    }
+  }, [updateRealPlaces, updateMapCenter, zoomToPlace]);
 
   const getDisplayTitle = () => {
     if (isNaturalLanguageSearch) {
       return "Smart Search Results";
     } else if (searchedCity && searchedCity.trim() !== "") {
       return `Explore Vibes in ${searchedCity}${searchedState ? `, ${searchedState}` : ''}`;
+    } else if (cityParam) {
+      return `Explore Vibes in ${cityParam}`;
     }
     return "Explore Vibes";
   };
@@ -86,16 +143,17 @@ const Explore = () => {
   return (
     <div className="min-h-screen bg-background">
       <Header />
-      
+
       <main className="container py-6">
         <div className="mb-6">
           <h1 className="text-3xl font-bold text-center mb-6 vibe-gradient-text">
             {getDisplayTitle()}
           </h1>
-          
-          <ExploreSearchSection 
+
+          <ExploreSearchSection
             searchQuery={searchQuery}
             onSearchChange={setSearchQuery}
+            onSearchSubmit={handleSmartSearch}
             dateRange={dateRange ? { from: dateRange.from!, to: dateRange.to! } : null}
             onDateChange={(dates) => handleDateRangeChange(dates ? { from: dates.from, to: dates.to } : null)}
             location={location}
@@ -103,7 +161,7 @@ const Explore = () => {
             onPlaceSelect={handlePlaceSelect}
             onVenueSelect={handleVenueSelect}
           />
-          
+
           <div className="w-full mb-6">
             <NearbyVibesMap />
           </div>
@@ -121,15 +179,15 @@ const Explore = () => {
               nightlifeVenues={nightlifeVenues}
               filteredLocations={filteredLocations}
               locationTags={locationTags}
-              searchedCity={searchedCity || ""}
+              searchedCity={searchedCity || cityParam || ""}
               dateRange={dateRange}
             />
           </div>
-          
+
           <ExploreSidebar isMobile={isMobile} />
         </div>
       </main>
-      
+
       <CameraButton />
     </div>
   );

--- a/src/pages/MyPlaces.tsx
+++ b/src/pages/MyPlaces.tsx
@@ -1,44 +1,95 @@
 
 import { Layout } from "@/components/Layout";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { mockLocations } from "@/mock/locations";
 import { Location } from "@/types";
-import { MapPin, Star, Clock, Car, ExternalLink, Calendar, UserPlus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import PlaceCard from "@/components/places/PlaceCard";
 import TripsList from "@/components/places/TripsList";
 import VibeWithMe from "@/components/places/VibeWithMe";
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
+import {
+  listUserPlaces,
+  getCurrentUserId,
+  UserPlaceRecord,
+} from "@/services/trips/tripCollabService";
+
+/**
+ * Maps a user_places row onto a full Location for rendering. We only persist the
+ * id/name/city, so we hydrate the rest from the mock catalog when available and
+ * otherwise synthesize a minimal Location.
+ */
+const recordToLocation = (record: UserPlaceRecord): Location => {
+  const match = mockLocations.find((l) => l.id === record.location_id);
+  if (match) return match;
+  return {
+    id: record.location_id,
+    name: record.location_name || "Saved place",
+    address: "",
+    city: record.location_city || "",
+    lat: 0,
+    lng: 0,
+    type: "attraction",
+  } as Location;
+};
 
 const MyPlaces = () => {
-  // Filter locations to get a subset for "Visited" and "Want to Visit"
-  const visitedPlaces = mockLocations.slice(0, 5);
-  const wantToVisitPlaces = mockLocations.slice(5, 10);
   const [activeSection, setActiveSection] = useState<"places" | "trips">("places");
+
+  // Mock fallback subsets used when signed out or the DB has no rows.
+  const mockVisited = mockLocations.slice(0, 5);
+  const mockWantToVisit = mockLocations.slice(5, 10);
+
+  const [visitedPlaces, setVisitedPlaces] = useState<Location[]>(mockVisited);
+  const [wantToVisitPlaces, setWantToVisitPlaces] = useState<Location[]>(mockWantToVisit);
+
+  const loadPlaces = useCallback(async () => {
+    const uid = await getCurrentUserId();
+    if (!uid) {
+      // Signed out: render the mock catalog.
+      setVisitedPlaces(mockVisited);
+      setWantToVisitPlaces(mockWantToVisit);
+      return;
+    }
+
+    const [visited, wanted] = await Promise.all([
+      listUserPlaces(uid, "visited"),
+      listUserPlaces(uid, "want_to_visit"),
+    ]);
+
+    setVisitedPlaces(visited.length > 0 ? visited.map(recordToLocation) : mockVisited);
+    setWantToVisitPlaces(
+      wanted.length > 0 ? wanted.map(recordToLocation) : mockWantToVisit,
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    loadPlaces();
+  }, [loadPlaces]);
 
   return (
     <Layout>
       <div className="container py-8">
         <h1 className="text-2xl font-bold mb-6">My Places</h1>
-        
+
         <div className="flex items-center space-x-4 mb-6">
-          <Button 
-            variant={activeSection === "places" ? "default" : "outline"} 
+          <Button
+            variant={activeSection === "places" ? "default" : "outline"}
             onClick={() => setActiveSection("places")}
             className="transition-all duration-300"
           >
             Places
           </Button>
-          <Button 
-            variant={activeSection === "trips" ? "default" : "outline"} 
+          <Button
+            variant={activeSection === "trips" ? "default" : "outline"}
             onClick={() => setActiveSection("trips")}
             className="transition-all duration-300"
           >
             Trips
           </Button>
         </div>
-        
+
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
           <div className="lg:col-span-2">
             {activeSection === "places" ? (
@@ -47,14 +98,14 @@ const MyPlaces = () => {
                   <TabsTrigger value="visited">Visited</TabsTrigger>
                   <TabsTrigger value="want-to-visit">Want to Visit</TabsTrigger>
                 </TabsList>
-                
+
                 <TabsContent value="visited" className="space-y-4">
                   <p className="text-muted-foreground mb-4">Places you've checked in at or marked as visited.</p>
                   {visitedPlaces.map((place) => (
                     <PlaceCard key={place.id} place={place} visitType="visited" />
                   ))}
                 </TabsContent>
-                
+
                 <TabsContent value="want-to-visit" className="space-y-4">
                   <p className="text-muted-foreground mb-4">Places you've saved to visit in the future.</p>
                   {wantToVisitPlaces.map((place) => (
@@ -66,12 +117,12 @@ const MyPlaces = () => {
               <TripsList />
             )}
           </div>
-          
+
           <div>
             <VibeWithMe className="mb-6" />
           </div>
         </div>
-        
+
         <div className="mt-8 rounded-lg bg-muted/50 p-4 text-xs text-muted-foreground">
           <p className="font-medium">Community Guidelines</p>
           <p className="mt-1">Post vibes that make others want to visit. No memes, flyers, or unrelated posts please.</p>

--- a/src/pages/PinnedVibes.tsx
+++ b/src/pages/PinnedVibes.tsx
@@ -1,139 +1,81 @@
 
+import { useEffect, useState } from "react";
 import { Layout } from "@/components/Layout";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
-import { MapPin, Clock, Bookmark, Share2 } from "lucide-react";
-import { formatDistanceToNow } from "date-fns";
-
-// Sample pinned content
-const pinnedPosts = [
-  {
-    id: "1",
-    venue: {
-      id: "123",
-      name: "Griffith Observatory",
-      type: "attraction",
-      city: "Los Angeles",
-      state: "CA",
-      image: "https://images.unsplash.com/photo-1518791841217-8f162f1e1131?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=60"
-    },
-    content: "Stunning views of LA from the Griffith Observatory. Perfect for sunset visits!",
-    media: {
-      type: "image",
-      url: "https://images.unsplash.com/photo-1566159196870-a69f1d122ae4?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80"
-    },
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3).toISOString()
-  },
-  {
-    id: "2",
-    venue: {
-      id: "456",
-      name: "The Getty",
-      type: "attraction",
-      city: "Los Angeles",
-      state: "CA",
-      image: "https://images.unsplash.com/photo-1518791841217-8f162f1e1131?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=60"
-    },
-    content: "Amazing art exhibits at The Getty today. The architecture is almost as impressive as the art itself!",
-    media: {
-      type: "image",
-      url: "https://images.unsplash.com/photo-1594132542197-3e73ebb341a0?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80"
-    },
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24 * 5).toISOString()
-  },
-  {
-    id: "3",
-    venue: {
-      id: "30",
-      name: "Lakers Game",
-      type: "sports",
-      city: "Los Angeles",
-      state: "CA",
-      image: "https://images.unsplash.com/photo-1518791841217-8f162f1e1131?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=60"
-    },
-    content: "Caught the Lakers game last night - incredible atmosphere at the Crypto.com Arena!",
-    media: {
-      type: "image",
-      url: "https://images.unsplash.com/photo-1504450758481-7338eba7524a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1169&q=80"
-    },
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24 * 2).toISOString()
-  }
-];
+import { Card, CardContent } from "@/components/ui/card";
+import { Bookmark, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import type { Post } from "@/types";
+import { postsRepo } from "@/services/data";
+import { getCurrentUserId } from "@/services/posts/currentUser";
+import PostCard from "@/components/post/PostCard";
 
 const PinnedVibes = () => {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    const load = async () => {
+      setLoading(true);
+      try {
+        // Use the signed-in user id, falling back to the first mock user so the demo
+        // renders saved content even when signed out (repo falls back to mock data).
+        const userId = (await getCurrentUserId()) ?? "user-1";
+        const saved = await postsRepo.getSaved(userId);
+        // Everything on this page is, by definition, saved — reflect that in the UI.
+        if (active) setPosts(saved.map((p) => ({ ...p, saved: true })));
+      } catch (error) {
+        console.error("Failed to load saved posts", error);
+        if (active) {
+          toast.error("Couldn't load your saved vibes.");
+          setPosts([]);
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const handlePostDeleted = (postId: string) => {
+    // PostFooter's save toggle removes it server-side; reflect removals locally too.
+    setPosts((prev) => prev.filter((p) => p.id !== postId));
+  };
+
   return (
     <Layout>
       <div className="container py-8">
         <h1 className="text-2xl font-bold mb-6">Pinned Vibes</h1>
         <p className="text-muted-foreground mb-6">Your saved posts and places for quick access.</p>
-        
-        <div className="space-y-6">
-          {pinnedPosts.map(post => (
-            <Card key={post.id} className="overflow-hidden">
-              <CardHeader className="p-4 pb-0">
-                <div className="flex justify-between items-start">
-                  <div className="flex items-center gap-2">
-                    <Avatar>
-                      <AvatarImage src={`https://source.unsplash.com/random/200x200/?${post.venue.type}`} alt={post.venue.name} />
-                      <AvatarFallback>{post.venue.name[0]}</AvatarFallback>
-                    </Avatar>
-                    <div>
-                      <div className="font-medium flex items-center">{post.venue.name}</div>
-                      <div className="text-sm text-muted-foreground">{post.venue.city}, {post.venue.state}</div>
-                    </div>
-                  </div>
-                  <div className="flex items-center text-sm text-muted-foreground">
-                    <Clock className="h-3 w-3 mr-1" />
-                    <span>Pinned {formatDistanceToNow(new Date(post.timestamp), { addSuffix: true })}</span>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent className="p-4">
-                <p className="mb-3">{post.content}</p>
-                <div className="rounded-lg overflow-hidden">
-                  {post.media.type === "image" ? (
-                    <img
-                      src={post.media.url}
-                      alt={`Media by ${post.venue.name}`}
-                      className="w-full h-auto object-cover rounded-md"
-                    />
-                  ) : (
-                    <video
-                      src={post.media.url}
-                      controls
-                      className="w-full h-auto rounded-md"
-                      poster="https://images.unsplash.com/photo-1478760329108-5c3ed9d495a0?ixlib=rb-1.2.1&auto=format&fit=crop&w=500&q=60"
-                    />
-                  )}
-                </div>
-                <div className="flex items-center gap-2 mt-3">
-                  <Badge variant="outline" className="bg-muted">{post.venue.type}</Badge>
-                  <div className="flex items-center ml-2 text-xs text-muted-foreground">
-                    <MapPin className="h-3 w-3 mr-1" />
-                    <span>{post.venue.city}, {post.venue.state}</span>
-                  </div>
-                </div>
-              </CardContent>
-              <CardFooter className="p-4 pt-0 flex justify-between">
-                <Button variant="ghost" size="sm" className="flex items-center gap-1">
-                  <Share2 className="h-4 w-4" />
-                  <span>Share</span>
-                </Button>
-                <Button 
-                  variant="outline"
-                  size="sm" 
-                  className="bg-amber-500/20 text-amber-500 border-amber-500/50 hover:bg-amber-500/30"
-                >
-                  <Bookmark className="h-4 w-4 mr-1" />
-                  Unpin
-                </Button>
-              </CardFooter>
-            </Card>
-          ))}
-        </div>
-        
+
+        {loading ? (
+          <div className="flex items-center justify-center py-16 text-muted-foreground">
+            <Loader2 className="h-5 w-5 mr-2 animate-spin" />
+            Loading your saved vibes...
+          </div>
+        ) : posts.length === 0 ? (
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground">
+              <Bookmark className="h-10 w-10 mb-3 opacity-50" />
+              <p className="font-medium">No saved vibes yet</p>
+              <p className="text-sm mt-1">Tap the bookmark on any post to pin it here.</p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-6">
+            {posts.map((post) => (
+              <PostCard
+                key={post.id}
+                post={post}
+                onPostDeleted={handlePostDeleted}
+              />
+            ))}
+          </div>
+        )}
+
         <div className="mt-8 rounded-lg bg-muted/50 p-4 text-xs text-muted-foreground">
           <p className="font-medium">Community Guidelines</p>
           <p className="mt-1">Post vibes that make others want to visit. No memes, flyers, or unrelated posts please.</p>

--- a/src/pages/ProfileBio.tsx
+++ b/src/pages/ProfileBio.tsx
@@ -1,31 +1,108 @@
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Layout } from "@/components/Layout";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Upload, Edit, Camera } from "lucide-react";
+import { Edit, Camera } from "lucide-react";
+import { toast } from "sonner";
+import { profilesRepo } from "@/services/data";
+import { useUserStore } from "@/store/userStore";
+import type { User } from "@/types";
 
 const ProfileBio = () => {
+  const { user: storeUser, isAuthenticated, updateUser } = useUserStore();
   const [isEditing, setIsEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [profile, setProfile] = useState<User | null>(null);
   const [profileData, setProfileData] = useState({
-    name: "Christian Amechi",
-    username: "@ChiefVibeOfficer",
-    bio: "Exploring the best vibes around the world. Always on the lookout for hidden gems and exciting experiences.",
-    location: "Los Angeles, CA",
-    joinedDate: "January 2023"
+    name: "",
+    username: "",
+    bio: "",
+    location: "",
+    avatar: "",
+    joinedDate: "",
   });
 
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      setLoading(true);
+      try {
+        // Load the signed-in user's profile; fall back to the first mock user when signed out.
+        const loaded = storeUser?.id
+          ? await profilesRepo.getById(storeUser.id)
+          : (await profilesRepo.listSuggested(1))[0] ?? null;
+
+        if (!active) return;
+        if (loaded) {
+          setProfile(loaded);
+          setProfileData({
+            name: loaded.displayName || loaded.name || "",
+            username: loaded.username ? `@${loaded.username}` : "",
+            bio: loaded.bio || "",
+            location: loaded.location || "",
+            avatar: loaded.avatar || "",
+            joinedDate: loaded.createdAt
+              ? new Date(loaded.createdAt).toLocaleDateString("en-US", {
+                  month: "long",
+                  year: "numeric",
+                })
+              : "",
+          });
+        }
+      } catch (err) {
+        console.warn("[ProfileBio] failed to load profile:", err);
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      active = false;
+    };
+  }, [storeUser?.id]);
+
   const handleEditToggle = () => {
+    if (!isAuthenticated) {
+      toast.error("Please sign in to edit your profile.");
+      return;
+    }
     setIsEditing(!isEditing);
   };
 
-  const handleSave = () => {
-    // In a real app, this would save to the backend
-    setIsEditing(false);
+  const handleSave = async () => {
+    if (!isAuthenticated || !storeUser?.id) {
+      toast.error("Please sign in to save your profile.");
+      return;
+    }
+    setSaving(true);
+    try {
+      const updates: Partial<User> = {
+        displayName: profileData.name,
+        name: profileData.name,
+        bio: profileData.bio,
+      };
+      const updated = await profilesRepo.update(storeUser.id, updates);
+      if (updated) {
+        setProfile(updated);
+      }
+      // Keep the Zustand store in sync.
+      updateUser({ name: profileData.name } as never);
+      setIsEditing(false);
+      toast.success("Profile updated");
+    } catch (err) {
+      console.warn("[ProfileBio] save failed:", err);
+      toast.error("Could not save profile. Please try again.");
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -37,8 +114,8 @@ const ProfileBio = () => {
             <div className="absolute -bottom-12 left-8">
               <div className="relative">
                 <Avatar className="h-24 w-24 border-4 border-background">
-                  <AvatarImage src="https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=300&h=300&q=80" alt={profileData.name} />
-                  <AvatarFallback>{profileData.name.charAt(0)}</AvatarFallback>
+                  <AvatarImage src={profileData.avatar} alt={profileData.name} />
+                  <AvatarFallback>{profileData.name.charAt(0) || "?"}</AvatarFallback>
                 </Avatar>
                 <Button variant="outline" size="icon" className="absolute bottom-0 right-0 rounded-full bg-background">
                   <Camera className="h-4 w-4" />
@@ -53,45 +130,50 @@ const ProfileBio = () => {
             </div>
           </CardHeader>
           <CardContent className="pt-16">
-            {isEditing ? (
+            {loading ? (
+              <div className="py-8 text-center text-muted-foreground">Loading profile...</div>
+            ) : isEditing ? (
               <div className="space-y-4">
                 <div className="grid grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label htmlFor="name">Name</Label>
-                    <Input 
-                      id="name" 
+                    <Input
+                      id="name"
                       value={profileData.name}
-                      onChange={(e) => setProfileData({...profileData, name: e.target.value})}
+                      onChange={(e) => setProfileData({ ...profileData, name: e.target.value })}
                     />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="username">Username</Label>
-                    <Input 
-                      id="username" 
+                    <Input
+                      id="username"
                       value={profileData.username}
-                      onChange={(e) => setProfileData({...profileData, username: e.target.value})}
+                      disabled
+                      onChange={(e) => setProfileData({ ...profileData, username: e.target.value })}
                     />
                   </div>
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="bio">Bio</Label>
-                  <Textarea 
-                    id="bio" 
+                  <Textarea
+                    id="bio"
                     value={profileData.bio}
-                    onChange={(e) => setProfileData({...profileData, bio: e.target.value})}
+                    onChange={(e) => setProfileData({ ...profileData, bio: e.target.value })}
                     rows={4}
                   />
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="location">Location</Label>
-                  <Input 
-                    id="location" 
+                  <Input
+                    id="location"
                     value={profileData.location}
-                    onChange={(e) => setProfileData({...profileData, location: e.target.value})}
+                    onChange={(e) => setProfileData({ ...profileData, location: e.target.value })}
                   />
                 </div>
                 <div className="flex justify-end">
-                  <Button onClick={handleSave}>Save Changes</Button>
+                  <Button onClick={handleSave} disabled={saving}>
+                    {saving ? "Saving..." : "Save Changes"}
+                  </Button>
                 </div>
               </div>
             ) : (
@@ -102,9 +184,9 @@ const ProfileBio = () => {
                 </div>
                 <p>{profileData.bio}</p>
                 <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <span>{profileData.location}</span>
-                  <span>•</span>
-                  <span>Joined {profileData.joinedDate}</span>
+                  {profileData.location && <span>{profileData.location}</span>}
+                  {profileData.location && profileData.joinedDate && <span>•</span>}
+                  {profileData.joinedDate && <span>Joined {profileData.joinedDate}</span>}
                 </div>
                 <div className="mt-8 rounded-lg bg-muted/50 p-4 text-xs text-muted-foreground">
                   <p className="font-medium">Community Guidelines</p>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -30,11 +30,12 @@ const Settings = () => {
   };
 
   const handleConnectPlatform = (platformId: string) => {
+    // Real OAuth account linking is out of scope for the demo; communicate clearly
+    // rather than implying a connection was established.
     toast({
-      title: "Connecting to platform",
-      description: `Initiating connection to ${platformId === 'other' ? "custom platform" : platformId}...`,
+      title: "Coming soon",
+      description: `Connecting ${platformId === 'other' ? "a custom platform" : platformId} accounts isn't available yet.`,
     });
-    // In a real app, this would trigger an OAuth flow or similar
   };
 
   const toggleMode = () => {

--- a/src/pages/UserPoints.tsx
+++ b/src/pages/UserPoints.tsx
@@ -1,11 +1,35 @@
 
+import { useEffect, useState } from "react";
 import { Layout } from "@/components/Layout";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { Award, TrendingUp, MapPin, Calendar, Clock, CheckCircle2, Ticket } from "lucide-react";
+import { Award, TrendingUp, Star } from "lucide-react";
+import { useUserStore } from "@/store/userStore";
+import { pointsService, type PointsLedgerEntry } from "@/services/social/pointsService";
 
 const UserPointsPage = () => {
+  const { user } = useUserStore();
+  const [totalPoints, setTotalPoints] = useState(1250);
+  const [ledger, setLedger] = useState<PointsLedgerEntry[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    Promise.all([
+      pointsService.getTotal(user?.id),
+      pointsService.getLedger(user?.id),
+    ])
+      .then(([total, entries]) => {
+        if (!active) return;
+        setTotalPoints(total);
+        setLedger(entries);
+      })
+      .catch((err) => console.warn("[UserPoints] load failed:", err));
+    return () => {
+      active = false;
+    };
+  }, [user?.id]);
+
   return (
     <Layout>
       <div className="container py-8">
@@ -19,7 +43,7 @@ const UserPointsPage = () => {
             </CardHeader>
             <CardContent>
               <div className="flex items-center justify-between">
-                <span className="text-3xl font-bold text-primary">1,250</span>
+                <span className="text-3xl font-bold text-primary">{totalPoints.toLocaleString()}</span>
                 <Award className="h-8 w-8 text-primary opacity-80" />
               </div>
             </CardContent>
@@ -71,49 +95,29 @@ const UserPointsPage = () => {
               </CardHeader>
               <CardContent>
                 <div className="space-y-4">
-                  {[
-                    { 
-                      action: "Checked in at Griffith Observatory", 
-                      points: 25, 
-                      date: "Apr 4, 2025", 
-                      icon: <MapPin className="h-4 w-4" /> 
-                    },
-                    { 
-                      action: "Posted a video at Crypto.com Arena", 
-                      points: 75, 
-                      date: "Apr 2, 2025",
-                      icon: <Calendar className="h-4 w-4" />
-                    },
-                    { 
-                      action: "5-day streak bonus", 
-                      points: 50, 
-                      date: "Apr 1, 2025",
-                      icon: <TrendingUp className="h-4 w-4" />
-                    },
-                    { 
-                      action: "Verified Venice Beach review", 
-                      points: 30, 
-                      date: "Mar 28, 2025",
-                      icon: <CheckCircle2 className="h-4 w-4" />
-                    },
-                    { 
-                      action: "Shared 3 locations", 
-                      points: 45, 
-                      date: "Mar 25, 2025",
-                      icon: <Clock className="h-4 w-4" />
-                    }
-                  ].map((item, index) => (
-                    <div key={index} className="flex items-center justify-between border-b border-border pb-3 last:border-0 last:pb-0">
+                  {ledger.length === 0 && (
+                    <p className="text-sm text-muted-foreground">No recent activity yet.</p>
+                  )}
+                  {ledger.map((item) => (
+                    <div key={item.id} className="flex items-center justify-between border-b border-border pb-3 last:border-0 last:pb-0">
                       <div className="flex items-center">
                         <div className="flex items-center justify-center h-8 w-8 rounded-full bg-primary/10 text-primary mr-3">
-                          {item.icon}
+                          <Star className="h-4 w-4" />
                         </div>
                         <div>
-                          <p className="font-medium">{item.action}</p>
-                          <p className="text-xs text-muted-foreground">{item.date}</p>
+                          <p className="font-medium">{item.reason}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {new Date(item.createdAt).toLocaleDateString("en-US", {
+                              month: "short",
+                              day: "numeric",
+                              year: "numeric",
+                            })}
+                          </p>
                         </div>
                       </div>
-                      <span className="font-semibold text-sm text-primary">+{item.points} pts</span>
+                      <span className="font-semibold text-sm text-primary">
+                        {item.points >= 0 ? "+" : ""}{item.points} pts
+                      </span>
                     </div>
                   ))}
                 </div>

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -6,11 +6,14 @@ import UserProfileHeader from '@/components/user/UserProfileHeader';
 import PrivateProfileContent from '@/components/user/PrivateProfileContent';
 import ProfileTabs from '@/components/user/ProfileTabs';
 import { useUserProfile } from '@/hooks/useUserProfile';
+import { useUserStore } from '@/store/userStore';
+import { toast } from 'sonner';
 
 const UserProfile = () => {
   const { username } = useParams<{ username: string }>();
   const navigate = useNavigate();
-  
+  const { user: currentUser, isAuthenticated } = useUserStore();
+
   const {
     profile,
     loading,
@@ -19,6 +22,7 @@ const UserProfile = () => {
     followedVenues,
     visitedPlaces,
     wantToVisitPlaces,
+    isFollowing,
     followUser,
     unfollowUser,
     updateBio,
@@ -27,6 +31,26 @@ const UserProfile = () => {
     getUserBio,
     isPrivateProfile
   } = useUserProfile(username || '');
+
+  const isOwnProfile = !!currentUser?.id && currentUser.id === profile?.id;
+
+  const handleFollow = async () => {
+    if (!isAuthenticated) {
+      toast.error('Please sign in to follow people.');
+      return false;
+    }
+    const ok = await followUser();
+    if (ok) toast.success(`Following ${profile?.name || 'user'}`);
+    return ok;
+  };
+
+  const handleUnfollow = async () => {
+    if (!isAuthenticated) {
+      toast.error('Please sign in to manage follows.');
+      return false;
+    }
+    return unfollowUser();
+  };
 
   useEffect(() => {
     if (!username) {
@@ -78,15 +102,17 @@ const UserProfile = () => {
           <PrivateProfileContent user={profile} />
         ) : (
           <>
-            <UserProfileHeader 
+            <UserProfileHeader
               user={profile}
-              onFollow={followUser}
-              onUnfollow={unfollowUser}
+              onFollow={handleFollow}
+              onUnfollow={handleUnfollow}
               onUpdateBio={updateBio}
               onBlock={blockUser}
               onReport={reportUser}
               isPrivate={isPrivateProfile}
-              getUserBio={() => getUserBio(profile.id)}
+              isFollowing={isFollowing}
+              isOwnProfile={isOwnProfile}
+              getUserBio={() => getUserBio()}
             />
             
             <ProfileTabs

--- a/src/pages/VenueProfile.tsx
+++ b/src/pages/VenueProfile.tsx
@@ -22,7 +22,7 @@ import VenuePostsContent from "@/components/venue/VenuePostsContent";
 import WaitTimeDisplay from "@/components/venue/WaitTimeDisplay";
 import WaitTimeUpdater from "@/components/venue/WaitTimeUpdater";
 import PremiumFeaturesContainer from "@/components/venue/PremiumFeaturesContainer";
-import { useAuth0 } from "@auth0/auth0-react";
+import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import { useUserSubscription } from "@/hooks/useUserSubscription";
 
 // Define an extended Post type that includes venue-specific properties
@@ -42,7 +42,7 @@ const VenueProfile = () => {
   const [isVenueOwner, setIsVenueOwner] = useState(false);
   const [subscriptionTier, setSubscriptionTier] = useState<'standard' | 'plus' | 'premium' | 'pro'>('standard');
   
-  const { user, isAuthenticated } = useAuth0();
+  const { user, isAuthenticated } = useSupabaseAuth();
   const { canAccessFeature } = useUserSubscription();
   
   const venue = mockLocations.find(location => location.id === id);

--- a/src/pages/VenueProfile.tsx
+++ b/src/pages/VenueProfile.tsx
@@ -3,18 +3,16 @@ import { useState, useMemo, useEffect, useRef } from "react";
 import { useParams } from "react-router-dom";
 import { Minimize } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { mockLocations, mockPosts, mockComments } from "@/mock/data";
+import { mockComments } from "@/mock/data";
 import CameraButton from "@/components/CameraButton";
 import Header from "@/components/Header";
-import { Comment, Post, Location as VenueLocation } from "@/types";
+import { Comment, Post, Location } from "@/types";
 import GoogleMapComponent, { GoogleMapHandle } from "@/components/map/google/GoogleMap";
 import { generateBusinessHours } from "@/utils/businessHoursUtils";
-import { 
-  isPostFromDayOfWeek, 
+import {
   isWithinThreeMonths,
   createDaySpecificVenuePosts
 } from "@/mock/time-utils";
-import { getVenueContent } from "@/utils/venue/venueContentHelpers";
 import DayOfWeekFilter from "@/components/venue/DayOfWeekFilter";
 import VenueProfileHeader from "@/components/venue/VenueProfileHeader";
 import VenueMap from "@/components/venue/VenueMap";
@@ -24,6 +22,7 @@ import WaitTimeUpdater from "@/components/venue/WaitTimeUpdater";
 import PremiumFeaturesContainer from "@/components/venue/PremiumFeaturesContainer";
 import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import { useUserSubscription } from "@/hooks/useUserSubscription";
+import { locationsRepo, postsRepo } from "@/services/data";
 
 // Define an extended Post type that includes venue-specific properties
 interface ExtendedPost extends Post {
@@ -41,12 +40,48 @@ const VenueProfile = () => {
   const mapRef = useRef<GoogleMapHandle>(null);
   const [isVenueOwner, setIsVenueOwner] = useState(false);
   const [subscriptionTier, setSubscriptionTier] = useState<'standard' | 'plus' | 'premium' | 'pro'>('standard');
-  
+
+  // Venue + posts are loaded from the data layer (Supabase with mock fallback).
+  const [venue, setVenue] = useState<Location | null>(null);
+  const [venuePosts, setVenuePosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+
   const { user, isAuthenticated } = useSupabaseAuth();
   const { canAccessFeature } = useUserSubscription();
-  
-  const venue = mockLocations.find(location => location.id === id);
-  
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setLoading(true);
+
+    Promise.all([locationsRepo.getById(id), postsRepo.getByVenue(id)])
+      .then(([loc, posts]) => {
+        if (cancelled) return;
+        if (loc) {
+          // Derive business hours from the venue data when not present.
+          if (!loc.hours) {
+            loc.hours = generateBusinessHours(loc);
+          }
+          setVenue(loc);
+        } else {
+          setVenue(null);
+        }
+        // Keep only posts from the last three months for the venue feed.
+        setVenuePosts((posts ?? []).filter((p) => isWithinThreeMonths(p.timestamp)));
+      })
+      .catch((err) => {
+        console.error("Error loading venue:", err);
+        if (!cancelled) setVenue(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
   useEffect(() => {
     if (isAuthenticated && user && venue) {
       if (user.email === 'owner@example.com') {
@@ -55,18 +90,9 @@ const VenueProfile = () => {
       }
     }
   }, [isAuthenticated, user, venue]);
-  
-  if (venue && !venue.hours) {
-    venue.hours = generateBusinessHours(venue);
-  }
-  
-  const venuePosts = useMemo(() => {
-    return mockPosts.filter(post => 
-      post.location.id === id && 
-      isWithinThreeMonths(post.timestamp)
-    );
-  }, [id]);
 
+  // Demo venue content (day-specific posts) generated from mock helpers as a fallback so
+  // the feed is never empty even when the DB has no venue posts.
   const generatedVenuePosts = useMemo(() => {
     if (!venue) return [];
     return createDaySpecificVenuePosts(venue.id, venue.type) as unknown as Post[];
@@ -76,25 +102,25 @@ const VenueProfile = () => {
     if (selectedDays.length === 0) {
       return venuePosts;
     }
-    
-    return venuePosts.filter(post => 
+
+    return venuePosts.filter(post =>
       selectedDays.includes(new Date(post.timestamp).getDay())
     );
   }, [venuePosts, selectedDays]);
 
   const allPosts = useMemo(() => {
     if (!venue) return [];
-    
-    const filteredVenuePosts = selectedDays.length === 0 
-      ? generatedVenuePosts 
-      : generatedVenuePosts.filter(post => 
+
+    const filteredVenuePosts = selectedDays.length === 0
+      ? generatedVenuePosts
+      : generatedVenuePosts.filter(post =>
           selectedDays.includes(new Date(post.timestamp).getDay())
         );
-    
-    const combined = [...filteredPosts, ...filteredVenuePosts].sort((a, b) => 
+
+    const combined = [...filteredPosts, ...filteredVenuePosts].sort((a, b) =>
       new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
     );
-    
+
     return combined;
   }, [filteredPosts, venue, generatedVenuePosts, selectedDays]);
 
@@ -104,12 +130,12 @@ const VenueProfile = () => {
 
   const toggleMapExpansion = () => {
     setIsMapExpanded(!isMapExpanded);
-    
+
     setTimeout(() => {
       mapRef.current?.resize();
     }, 10);
   };
-  
+
   const handleDayToggle = (dayIndex: number) => {
     setSelectedDays(prev => {
       if (prev.includes(dayIndex)) {
@@ -119,10 +145,21 @@ const VenueProfile = () => {
       }
     });
   };
-  
+
   const clearDayFilters = () => {
     setSelectedDays([]);
   };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background">
+        <Header />
+        <div className="container py-20 text-center">
+          <p className="text-muted-foreground">Loading venue...</p>
+        </div>
+      </div>
+    );
+  }
 
   if (!venue) {
     return (
@@ -142,7 +179,7 @@ const VenueProfile = () => {
   return (
     <div className="min-h-screen bg-background">
       <Header />
-      
+
       {isMapExpanded && (
         <div className="fixed inset-0 z-50 bg-background p-4">
           <div className="flex justify-between items-center mb-4">
@@ -166,37 +203,37 @@ const VenueProfile = () => {
           </div>
         </div>
       )}
-      
+
       <main className="container py-6">
         <div className="max-w-4xl mx-auto">
           <div className="glass-effect p-6 rounded-xl mb-6">
             <VenueProfileHeader venue={venue} onMapExpand={toggleMapExpansion} />
-            
+
             <WaitTimeDisplay venueId={venue.id} className="mb-4" />
-            
+
             <VenueMap venue={venue} onExpand={toggleMapExpansion} />
-            
+
             {isVenueOwner && (
               <div className="mt-4">
-                <WaitTimeUpdater 
-                  venueId={venue.id} 
-                  subscriptionTier={subscriptionTier} 
+                <WaitTimeUpdater
+                  venueId={venue.id}
+                  subscriptionTier={subscriptionTier}
                 />
               </div>
             )}
           </div>
-          
-          <PremiumFeaturesContainer 
+
+          <PremiumFeaturesContainer
             venueId={venue.id}
             venueName={venue.name}
           />
-          
-          <DayOfWeekFilter 
-            selectedDays={selectedDays} 
-            onDayToggle={handleDayToggle} 
-            onClearFilters={clearDayFilters} 
+
+          <DayOfWeekFilter
+            selectedDays={selectedDays}
+            onDayToggle={handleDayToggle}
+            onClearFilters={clearDayFilters}
           />
-          
+
           <VenuePostsContent
             activeTab={activeTab}
             setActiveTab={setActiveTab}
@@ -211,7 +248,7 @@ const VenueProfile = () => {
           />
         </div>
       </main>
-      
+
       <CameraButton />
     </div>
   );

--- a/src/pages/settings/AccountTab.tsx
+++ b/src/pages/settings/AccountTab.tsx
@@ -1,11 +1,15 @@
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Crown } from "lucide-react";
+import { toast } from "sonner";
+import { profilesRepo } from "@/services/data";
+import { useUserStore } from "@/store";
+import { useSettingsPreferences } from "@/services/settings/useSettingsPreferences";
 
 export interface AccountTabProps {
   onSave: () => void;
@@ -13,14 +17,60 @@ export interface AccountTabProps {
   subscriptionTier?: 'standard' | 'plus' | 'premium' | 'pro';
 }
 
-const AccountTab = ({ 
-  onSave, 
-  isVenueMode = false, 
-  subscriptionTier = 'standard' 
+const AccountTab = ({
+  onSave,
+  isVenueMode = false,
+  subscriptionTier = 'standard'
 }: AccountTabProps) => {
+  const { user, isAuthenticated, updateUser } = useUserStore();
+  const { preferences, loaded, save: savePreferences } = useSettingsPreferences();
   const [emailNotifications, setEmailNotifications] = useState(true);
   const [twoFactorEnabled, setTwoFactorEnabled] = useState(false);
-  
+  const [displayName, setDisplayName] = useState("");
+  const [email, setEmail] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  // Hydrate profile fields from the signed-in user (falls back to demo placeholders).
+  useEffect(() => {
+    setDisplayName(user?.name ?? "Jane Smith");
+    setEmail(user?.email ?? "jane.smith@example.com");
+  }, [user?.name, user?.email]);
+
+  // Hydrate notification/security toggles from persisted preferences.
+  useEffect(() => {
+    if (!loaded) return;
+    if (typeof preferences.emailNotifications === "boolean")
+      setEmailNotifications(preferences.emailNotifications);
+    if (typeof preferences.twoFactorEnabled === "boolean")
+      setTwoFactorEnabled(preferences.twoFactorEnabled);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded]);
+
+  const handleSaveAccount = async () => {
+    setSaving(true);
+    try {
+      // Persist account toggles (works signed out via localStorage).
+      await savePreferences(
+        { emailNotifications, twoFactorEnabled },
+        { silent: true },
+      );
+
+      // Persist profile fields only when signed in.
+      if (isAuthenticated && user?.id) {
+        await profilesRepo.update(user.id, { displayName, name: displayName });
+        updateUser({ name: displayName });
+        toast.success("Account settings saved");
+      } else {
+        toast.info("Saved on this device. Sign in to update your profile.");
+      }
+    } catch (err) {
+      console.warn("[AccountTab] save failed", err);
+      toast.error("Could not save account settings.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const renderSubscriptionBadge = () => {
     if (!isVenueMode || subscriptionTier === 'standard') return null;
     
@@ -53,11 +103,20 @@ const AccountTab = ({
           <div className="grid gap-4">
             <div className="grid gap-2">
               <Label htmlFor="display-name">Display Name</Label>
-              <Input id="display-name" defaultValue="Jane Smith" />
+              <Input
+                id="display-name"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+              />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="email">Email</Label>
-              <Input id="email" type="email" defaultValue="jane.smith@example.com" />
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="username">Username</Label>
@@ -150,16 +209,25 @@ const AccountTab = ({
                   </p>
                   
                   <div className="grid grid-cols-2 gap-2">
-                    <Button variant="outline" size="sm">Manage Subscription</Button>
-                    <Button size="sm">Upgrade Plan</Button>
+                    <Button variant="outline" size="sm" disabled title="Coming soon">
+                      Manage Subscription
+                    </Button>
+                    <Button size="sm" disabled title="Coming soon">
+                      Upgrade Plan
+                    </Button>
                   </div>
+                  <p className="text-xs text-muted-foreground mt-2">
+                    Billing management is coming soon.
+                  </p>
                 </div>
               </div>
             )}
           </>
         )}
         
-        <Button onClick={onSave} className="w-full">Save Changes</Button>
+        <Button onClick={handleSaveAccount} disabled={saving} className="w-full">
+          {saving ? "Saving..." : "Save Changes"}
+        </Button>
       </div>
     </div>
   );

--- a/src/pages/settings/PreferencesTab.tsx
+++ b/src/pages/settings/PreferencesTab.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { PREFERENCE_TAGS, PREFERENCE_CATEGORIES } from "./constants";
 import { useToast } from "@/hooks/use-toast";
+import { useSettingsPreferences } from "@/services/settings/useSettingsPreferences";
 
 // Import components
 import UserPreferences from "./components/UserPreferences";
@@ -31,8 +32,43 @@ const PreferencesTab = ({
   const [suggestedTags, setSuggestedTags] = useState<string[]>([]);
   const [newTag, setNewTag] = useState("");
   const [favorites, setFavorites] = useState<string[]>([]);
-  
+
+  const { preferences, loaded, saving, save } = useSettingsPreferences();
   const { toast } = useToast();
+
+  // Hydrate from persisted preferences once they load.
+  useEffect(() => {
+    if (!loaded) return;
+    if (typeof preferences.distanceUnit === "string") setDistanceUnit(preferences.distanceUnit);
+    if (typeof preferences.searchRadius === "number") setSearchRadius([preferences.searchRadius]);
+    if (typeof preferences.showNearbyLocations === "boolean")
+      setShowNearbyLocations(preferences.showNearbyLocations);
+    if (typeof preferences.autoplayVideos === "boolean")
+      setAutoplayVideos(preferences.autoplayVideos);
+    if (Array.isArray(preferences.preferenceTags))
+      setSelectedTags(preferences.preferenceTags as string[]);
+    if (Array.isArray(preferences.favorites)) setFavorites(preferences.favorites as string[]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded]);
+
+  const handleSavePreferences = async () => {
+    try {
+      await save(
+        {
+          distanceUnit,
+          searchRadius: searchRadius[0],
+          showNearbyLocations,
+          autoplayVideos,
+          preferenceTags: selectedTags,
+          favorites,
+        },
+        { silent: true },
+      );
+    } catch {
+      /* toast handled in hook */
+    }
+    onSave();
+  };
   const [competitorVenues, setCompetitorVenues] = useState([
     { id: 1, name: "The Corner Bar", tags: ["Cozy", "Lounges", "Date Night"] },
     { id: 2, name: "Downtown Café", tags: ["Cozy", "Locally Owned", "Budget Friendly"] },
@@ -156,7 +192,9 @@ const PreferencesTab = ({
           <VenueDisplaySettings />
         )}
         
-        <Button onClick={onSave} className="w-full">Save Preferences</Button>
+        <Button onClick={handleSavePreferences} disabled={saving} className="w-full">
+          {saving ? "Saving..." : "Save Preferences"}
+        </Button>
       </div>
     </div>
   );

--- a/src/pages/settings/PrivacyTab.tsx
+++ b/src/pages/settings/PrivacyTab.tsx
@@ -1,5 +1,5 @@
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
@@ -7,6 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Input } from "@/components/ui/input";
 import { PlusCircle, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { useSettingsPreferences } from "@/services/settings/useSettingsPreferences";
 
 export interface PrivacyTabProps {
   onSave: () => void;
@@ -14,6 +15,7 @@ export interface PrivacyTabProps {
 }
 
 const PrivacyTab = ({ onSave, isVenueMode = false }: PrivacyTabProps) => {
+  const { preferences, loaded, saving, save } = useSettingsPreferences();
   const [locationTracking, setLocationTracking] = useState(true);
   const [profileVisibility, setProfileVisibility] = useState("public");
   const [dataSharing, setDataSharing] = useState(true);
@@ -21,7 +23,43 @@ const PrivacyTab = ({ onSave, isVenueMode = false }: PrivacyTabProps) => {
   const [vibeWithMeEnabled, setVibeWithMeEnabled] = useState(false);
   const [closeFriendInput, setCloseFriendInput] = useState("");
   const [closeFriends, setCloseFriends] = useState<string[]>([]);
-  
+
+  // Hydrate from persisted preferences.
+  useEffect(() => {
+    if (!loaded) return;
+    if (typeof preferences.locationTracking === "boolean")
+      setLocationTracking(preferences.locationTracking);
+    if (typeof preferences.profileVisibility === "string")
+      setProfileVisibility(preferences.profileVisibility);
+    if (typeof preferences.dataSharing === "boolean") setDataSharing(preferences.dataSharing);
+    if (typeof preferences.activityTracking === "boolean")
+      setActivityTracking(preferences.activityTracking);
+    if (typeof preferences.vibeWithMeEnabled === "boolean")
+      setVibeWithMeEnabled(preferences.vibeWithMeEnabled);
+    if (Array.isArray(preferences.closeFriends))
+      setCloseFriends(preferences.closeFriends as string[]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded]);
+
+  const handleSavePrivacy = async () => {
+    try {
+      await save(
+        {
+          locationTracking,
+          profileVisibility,
+          dataSharing,
+          activityTracking,
+          vibeWithMeEnabled,
+          closeFriends,
+        },
+        { silent: true },
+      );
+    } catch {
+      /* toast handled in hook */
+    }
+    onSave();
+  };
+
   const handleAddCloseFriend = () => {
     if (closeFriendInput.trim() && !closeFriends.includes(closeFriendInput.trim())) {
       setCloseFriends([...closeFriends, closeFriendInput.trim()]);
@@ -249,7 +287,9 @@ const PrivacyTab = ({ onSave, isVenueMode = false }: PrivacyTabProps) => {
           </div>
         )}
         
-        <Button onClick={onSave} className="w-full">Save Privacy Settings</Button>
+        <Button onClick={handleSavePrivacy} disabled={saving} className="w-full">
+          {saving ? "Saving..." : "Save Privacy Settings"}
+        </Button>
       </div>
     </div>
   );

--- a/src/services/AgentService.ts
+++ b/src/services/AgentService.ts
@@ -1,24 +1,34 @@
 
 // Agent Service for generating responses to user queries
+import { invokeEdgeWithFallback } from '@/services/edge/invokeEdge';
 
 class AgentServiceClass {
-  // Generate a response for a given query
+  // Generate a response for a given query.
+  // Routes through the `agent-protocol` edge function, then `vertex-ai`, then
+  // the canned mock responses below so it always returns something.
   async generateResponse(query: string, isVenueMode: boolean = false): Promise<string> {
-    try {
-      console.log(`Generating ${isVenueMode ? 'venue' : 'event'} agent response for: ${query}`);
-      
-      // Here you would typically make an API call to an LLM service
-      // For now, we'll return mock responses based on the query type
-      
-      if (isVenueMode) {
-        return this.generateVenueResponse(query);
-      } else {
-        return this.generateEventResponse(query);
-      }
-    } catch (error) {
-      console.error('Error in agent service:', error);
-      throw new Error('Failed to generate agent response');
+    const mode = isVenueMode ? 'venue' : 'event';
+    const cannedFallback = () =>
+      isVenueMode ? this.generateVenueResponse(query) : this.generateEventResponse(query);
+
+    const data = await invokeEdgeWithFallback<unknown>(
+      'agent-protocol',
+      { query, mode },
+      async () =>
+        invokeEdgeWithFallback<unknown>(
+          'vertex-ai',
+          { prompt: query, mode },
+          cannedFallback
+        )
+    );
+
+    if (typeof data === 'string' && data.trim()) return data;
+    if (data && typeof data === 'object') {
+      const obj = data as Record<string, any>;
+      const text = obj.text || obj.response || obj.content || obj.message;
+      if (typeof text === 'string' && text.trim()) return text;
     }
+    return cannedFallback();
   }
   
   // Generate venue-specific responses

--- a/src/services/HuggingChatService.ts
+++ b/src/services/HuggingChatService.ts
@@ -1,10 +1,33 @@
 
-// Service to interact with a free, keyless chat service
+import { invokeEdgeWithFallback } from '@/services/edge/invokeEdge';
+
+// Service to interact with a free, keyless chat service.
+// Routes through the `perplexity-search` edge function for live answers and
+// DEGRADES to the deterministic city/keyword canned responses below so it
+// always replies with venue links even with zero API keys.
 export const HuggingChatService = {
   async searchHuggingChat(query: string): Promise<string> {
+    const data = await invokeEdgeWithFallback<unknown>(
+      'perplexity-search',
+      { query },
+      () => generateCannedResponse(query)
+    );
+
+    if (typeof data === 'string' && data.trim()) return data;
+    if (data && typeof data === 'object') {
+      const obj = data as Record<string, any>;
+      const text = obj.text || obj.response || obj.answer || obj.content;
+      if (typeof text === 'string' && text.trim()) return text;
+    }
+    return generateCannedResponse(query);
+  },
+};
+
+// Deterministic, keyless canned response (original mock behavior preserved).
+function generateCannedResponse(query: string): string {
     try {
-      console.log('Searching for:', query);
-      
+      console.log('Generating canned response for:', query);
+
       // Mock data for city-based queries to demonstrate venue linking
       const cityKeywords = ['new york', 'los angeles', 'san francisco', 'chicago', 'miami', 'boston', 'austin', 'portland', 'seattle', 'denver'];
       const containsCityKeyword = cityKeywords.some(city => query.toLowerCase().includes(city));
@@ -61,8 +84,7 @@ export const HuggingChatService = {
       console.error('Error generating response:', error);
       return "I'm having a bit of trouble right now. Could you try asking your question again?";
     }
-  }
-};
+}
 
 // Helper function to generate city-specific responses with venue links
 function generateCityResponse(query: string): string {

--- a/src/services/HuggingFaceService.ts
+++ b/src/services/HuggingFaceService.ts
@@ -1,4 +1,6 @@
 
+import { invokeEdgeWithFallback } from '@/services/edge/invokeEdge';
+
 /**
  * Service for interacting with Hugging Face Transformers
  */
@@ -89,15 +91,20 @@ export class HuggingFaceService {
    * Generate text using a pre-trained model
    */
   static async generateText(prompt: string): Promise<string> {
-    try {
-      // In a production environment, we would use the Hugging Face API or a local model
-      // For now, we'll simulate text generation
-      await new Promise(resolve => setTimeout(resolve, 300));
-      
-      return `Here's information about "${prompt}" based on my knowledge.`;
-    } catch (error) {
-      console.error('Error generating text with HuggingFace:', error);
-      return 'Sorry, I could not generate information at this time.';
+    const fallback = () => `Here's information about "${prompt}" based on my knowledge.`;
+    const data = await invokeEdgeWithFallback<unknown>(
+      'vertex-ai',
+      { prompt, mode: 'default' },
+      async () =>
+        invokeEdgeWithFallback<unknown>('openai-chat', { prompt }, fallback)
+    );
+
+    if (typeof data === 'string' && data.trim()) return data;
+    if (data && typeof data === 'object') {
+      const obj = data as Record<string, any>;
+      const text = obj.text || obj.response || obj.content;
+      if (typeof text === 'string' && text.trim()) return text;
     }
+    return fallback();
   }
 }

--- a/src/services/OpenAIService.ts
+++ b/src/services/OpenAIService.ts
@@ -1,3 +1,4 @@
+import { invokeEdgeWithFallback } from '@/services/edge/invokeEdge';
 
 interface OpenAIMessage {
   role: 'system' | 'user' | 'assistant';
@@ -23,7 +24,83 @@ export class OpenAIService {
   private static readonly TTS_URL = 'https://api.openai.com/v1/audio/speech';
   private static readonly DEFAULT_MODEL = 'gpt-4o-mini';
 
+  /**
+   * Generate a chat completion. Routing order:
+   *   1. `vertex-ai` edge function (primary)
+   *   2. `openai-chat` edge function (fallback)
+   *   3. Direct OpenAI/OpenRouter fetch when a browser key is present
+   *   4. Canned local response so the chat ALWAYS replies (zero keys)
+   */
   static async generateResponse(
+    prompt: string,
+    context: Array<{ sender: string; text: string }> = [],
+    chatMode: 'user' | 'venue' = 'user'
+  ): Promise<string> {
+    const history = context.map((msg) => ({
+      sender: msg.sender === 'user' ? 'user' : 'ai',
+      text: msg.text,
+    }));
+
+    // 1) Primary: vertex-ai edge -> 2) openai-chat edge -> 3) direct fetch -> 4) canned
+    return invokeEdgeWithFallback<string>(
+      'vertex-ai',
+      {
+        prompt,
+        history,
+        mode: chatMode === 'venue' ? 'venue' : 'default',
+        systemPrompt: this.getSystemMessage(chatMode),
+        temperature: 0.7,
+        maxTokens: 1000,
+      },
+      async () =>
+        invokeEdgeWithFallback<string>(
+          'openai-chat',
+          {
+            prompt,
+            messages: [
+              { role: 'system', content: this.getSystemMessage(chatMode) },
+              ...context.slice(-5).map((msg) => ({
+                role: msg.sender === 'user' ? 'user' : 'assistant',
+                content: msg.text,
+              })),
+              { role: 'user', content: prompt },
+            ],
+            chatMode,
+          },
+          async () => {
+            try {
+              return await this.directFetchResponse(prompt, context, chatMode);
+            } catch (error) {
+              console.warn('OpenAI direct fetch unavailable, using canned response:', error);
+              return this.getCannedResponse(prompt, chatMode);
+            }
+          }
+        )
+    ).then((data) => this.extractText(data, prompt, chatMode));
+  }
+
+  /** Normalize whatever shape an edge function returns into a string. */
+  private static extractText(
+    data: unknown,
+    prompt: string,
+    chatMode: 'user' | 'venue'
+  ): string {
+    if (typeof data === 'string' && data.trim()) return data;
+    if (data && typeof data === 'object') {
+      const obj = data as Record<string, any>;
+      const text =
+        obj.text ||
+        obj.response ||
+        obj.content ||
+        obj.message ||
+        obj.choices?.[0]?.message?.content;
+      if (typeof text === 'string' && text.trim()) return text;
+    }
+    return this.getCannedResponse(prompt, chatMode);
+  }
+
+  /** Direct browser-side OpenAI/OpenRouter call (only when a key exists). */
+  private static async directFetchResponse(
     prompt: string,
     context: Array<{ sender: string; text: string }> = [],
     chatMode: 'user' | 'venue' = 'user'
@@ -123,42 +200,83 @@ export class OpenAIService {
   }
 
   // Text-to-speech method for voice functionality
+  /**
+   * Text-to-speech. Routes through the `eleven-labs-tts` edge function (then
+   * `google-tts`) and DEGRADES to an empty string silently when no audio
+   * backend is available so the caller can fall back to text-only.
+   */
   static async textToSpeech(text: string): Promise<string> {
-    try {
-      const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
-      
-      if (!apiKey) {
-        throw new Error('OpenAI API key required for text-to-speech');
+    return invokeEdgeWithFallback<string>(
+      'eleven-labs-tts',
+      { text },
+      async () =>
+        invokeEdgeWithFallback<string>(
+          'google-tts',
+          { text },
+          async () => {
+            // Last resort: direct OpenAI TTS only when a browser key exists.
+            try {
+              const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+              if (!apiKey) return '';
+
+              const response = await fetch(this.TTS_URL, {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Authorization: `Bearer ${apiKey}`,
+                },
+                body: JSON.stringify({
+                  model: 'tts-1',
+                  input: text,
+                  voice: 'alloy',
+                  response_format: 'mp3',
+                }),
+              });
+
+              if (!response.ok) return '';
+
+              const audioBuffer = await response.arrayBuffer();
+              return btoa(
+                new Uint8Array(audioBuffer).reduce(
+                  (data, byte) => data + String.fromCharCode(byte),
+                  ''
+                )
+              );
+            } catch (error) {
+              console.warn('TTS unavailable, degrading to text-only:', error);
+              return '';
+            }
+          }
+        )
+    ).then((data) => {
+      if (typeof data === 'string') return data;
+      if (data && typeof data === 'object') {
+        const obj = data as Record<string, any>;
+        return obj.audioContent || obj.audio || obj.base64 || '';
       }
+      return '';
+    });
+  }
 
-      const response = await fetch(this.TTS_URL, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${apiKey}`
-        },
-        body: JSON.stringify({
-          model: 'tts-1',
-          input: text,
-          voice: 'alloy',
-          response_format: 'mp3'
-        })
-      });
-
-      if (!response.ok) {
-        throw new Error(`TTS API error: ${response.status}`);
-      }
-
-      const audioBuffer = await response.arrayBuffer();
-      const base64Audio = btoa(
-        new Uint8Array(audioBuffer).reduce((data, byte) => data + String.fromCharCode(byte), '')
-      );
-      
-      return base64Audio;
-    } catch (error) {
-      console.error('Error with text-to-speech:', error);
-      throw error;
+  /**
+   * Local canned response used when no edge function and no browser key are
+   * available, so Vernon always replies.
+   */
+  private static getCannedResponse(prompt: string, chatMode: 'user' | 'venue'): string {
+    const q = prompt.toLowerCase();
+    if (chatMode === 'venue') {
+      return "Here's a quick take: focus on your peak nights (Thu-Sat), lean into your standout vibe, and keep your social posts consistent. I can dig into specific metrics whenever you connect your venue data.";
     }
+    if (/restaurant|food|eat|dinner|lunch|brunch/.test(q)) {
+      return "I'd start with a couple of well-rated local spots — tell me a city or neighborhood and I'll pull up real venues for you.";
+    }
+    if (/bar|drink|nightlife|club/.test(q)) {
+      return "For a good night out, give me a city and I'll surface bars and lounges that match your vibe.";
+    }
+    if (/coffee|cafe/.test(q)) {
+      return "Looking for coffee? Let me know where you are and I'll find cozy cafes nearby.";
+    }
+    return "I'm Vernon, your guide to great places and things to do. Tell me what you're in the mood for and where, and I'll find real venues for you.";
   }
 
   private static getSystemMessage(chatMode: 'user' | 'venue'): string {

--- a/src/services/PerplexityService.ts
+++ b/src/services/PerplexityService.ts
@@ -1,51 +1,73 @@
 
-import { supabase } from '@/integrations/supabase/client';
-import { SearchService } from './search/SearchService';
+import { invokeEdgeWithFallback } from '@/services/edge/invokeEdge';
+import { locationsRepo } from '@/services/data';
 
 /**
- * Service to interact with search APIs and AI-assisted search
- * This is kept for backward compatibility but delegates to the new SearchService
+ * NL / online search service backed by the `perplexity-search` edge function.
+ *
+ * When the edge call is unavailable we fall back to a local answer built from
+ * REAL venues via `locationsRepo` (with mock fallback). We deliberately do NOT
+ * call back into SearchService here to avoid recursion.
  */
+
+function extractText(data: unknown): string {
+  if (typeof data === 'string' && data.trim()) return data;
+  if (data && typeof data === 'object') {
+    const obj = data as Record<string, any>;
+    const text = obj.text || obj.response || obj.answer || obj.content;
+    if (typeof text === 'string' && text.trim()) return text;
+  }
+  return '';
+}
+
+async function localVenueAnswer(query: string): Promise<string> {
+  try {
+    const venues = await locationsRepo.search(query, 6);
+    if (venues.length > 0) {
+      const lines = venues.map(
+        (v) =>
+          `- [${v.name}](/venue/${encodeURIComponent(v.id)})${
+            v.city ? ` — ${v.type ? v.type + ' • ' : ''}${v.city}` : ''
+          }`
+      );
+      return [
+        "Here are some places I found that match what you're looking for:",
+        '',
+        ...lines,
+        '',
+        `[See more on the Explore page](/explore?q=${encodeURIComponent(query)})`,
+      ].join('\n');
+    }
+  } catch (error) {
+    console.warn('PerplexityService local venue fallback failed:', error);
+  }
+  return `I couldn't pull live results for "${query}" right now, but tell me a city or the kind of place you want and I'll find real venues for you.`;
+}
+
 export const PerplexityService = {
   /**
-   * Generate a chat completion using Perplexity
+   * Generate a chat-style answer using the Perplexity search edge function.
    */
   async generateResponse(prompt: string): Promise<string> {
-    try {
-      const { data, error } = await supabase.functions.invoke('perplexity-search', {
-        body: { query: prompt }
-      });
-
-      if (error) {
-        console.error('Perplexity API error:', error);
-        throw new Error('Failed to generate response');
-      }
-
-      return data?.text || '';
-    } catch (err) {
-      console.error('Perplexity generateResponse error:', err);
-      return "I'm having trouble connecting to my AI services right now.";
-    }
+    const data = await invokeEdgeWithFallback<unknown>(
+      'perplexity-search',
+      { query: prompt },
+      () => localVenueAnswer(prompt)
+    );
+    const text = extractText(data);
+    return text || (await localVenueAnswer(prompt));
   },
 
   /**
-   * Search using Perplexity with fallbacks
+   * Search using Perplexity with a local, real-venue fallback.
    */
   async searchPerplexity(query: string): Promise<string> {
-    try {
-      const { data, error } = await supabase.functions.invoke('perplexity-search', {
-        body: { query }
-      });
-
-      if (error) {
-        console.error('Perplexity search error:', error);
-        return SearchService.search(query);
-      }
-
-      return data?.text || SearchService.search(query);
-    } catch (err) {
-      console.error('Perplexity search exception:', err);
-      return SearchService.search(query);
-    }
-  }
+    const data = await invokeEdgeWithFallback<unknown>(
+      'perplexity-search',
+      { query },
+      () => localVenueAnswer(query)
+    );
+    const text = extractText(data);
+    return text || (await localVenueAnswer(query));
+  },
 };

--- a/src/services/VertexAI/analysis.ts
+++ b/src/services/VertexAI/analysis.ts
@@ -1,8 +1,32 @@
 
 /**
- * Extract categories from text using Google Cloud Natural Language API
- * @param text Text to analyze
- * @returns Array of detected categories
+ * Entity & category analysis. NLP-heavy calls (entities/sentiment) route
+ * through the `google-nlp` edge function and DEGRADE to deterministic local
+ * rule-based passes so results are always available with zero keys.
+ */
+import { invokeEdgeWithFallback } from '@/services/edge/invokeEdge';
+
+/**
+ * Local rule-based entity extraction used as the offline fallback.
+ */
+const localExtractEntities = (text: string): string[] => {
+  const entities: string[] = [];
+  const cityRegex =
+    /\b(?:chicago|new york|los angeles|san francisco|miami|austin|seattle|boston|portland|nashville|denver|dallas|atlanta)\b/gi;
+  const cityMatches = text.match(cityRegex);
+  if (cityMatches) cityMatches.forEach((city) => entities.push(city));
+
+  const venueRegex =
+    /\b(?:club|theater|venue|bar|restaurant|cafe|stadium|arena|gallery|museum)\b/gi;
+  const venueMatches = text.match(venueRegex);
+  if (venueMatches) venueMatches.forEach((venue) => entities.push(venue));
+
+  return entities;
+};
+
+/**
+ * Extract categories from text. Rule-based and deterministic (no network call
+ * needed), kept as the source of truth for category routing.
  */
 export const extractCategories = async (text: string): Promise<string[]> => {
   try {
@@ -42,39 +66,50 @@ export const extractCategories = async (text: string): Promise<string[]> => {
   }
 };
 
-// Add these missing methods that are referenced in the code
+/**
+ * Analyze text (sentiment + entities + categories) via the `google-nlp` edge
+ * function, falling back to local heuristics.
+ */
 export const analyzeText = async (text: string): Promise<any> => {
-  try {
-    // Simple implementation for now
-    return { sentiment: 0, entities: [], categories: await extractCategories(text) };
-  } catch (error) {
-    console.error('Error analyzing text:', error);
-    return { sentiment: 0, entities: [], categories: [] };
+  const fallback = async () => ({
+    sentiment: 0,
+    entities: localExtractEntities(text),
+    categories: await extractCategories(text),
+  });
+
+  const data = await invokeEdgeWithFallback<any>('google-nlp', { text }, fallback);
+
+  if (data && typeof data === 'object') {
+    return {
+      sentiment: data.sentiment ?? data.score ?? 0,
+      entities: Array.isArray(data.entities)
+        ? data.entities.map((e: any) => (typeof e === 'string' ? e : e?.name)).filter(Boolean)
+        : localExtractEntities(text),
+      categories:
+        Array.isArray(data.categories) && data.categories.length
+          ? data.categories
+          : await extractCategories(text),
+    };
   }
+  return fallback();
 };
 
+/**
+ * Extract named entities via `google-nlp`, falling back to local regex.
+ */
 export const extractEntities = async (text: string): Promise<string[]> => {
-  try {
-    // Simple implementation for now
-    const entities: string[] = [];
-    
-    // Look for cities
-    const cityRegex = /\b(?:chicago|new york|los angeles|san francisco|miami|austin|seattle|boston|portland|nashville|denver|dallas|atlanta)\b/gi;
-    const cityMatches = text.match(cityRegex);
-    if (cityMatches) {
-      cityMatches.forEach(city => entities.push(city));
-    }
-    
-    // Look for venue types
-    const venueRegex = /\b(?:club|theater|venue|bar|restaurant|cafe|stadium|arena|gallery|museum)\b/gi;
-    const venueMatches = text.match(venueRegex);
-    if (venueMatches) {
-      venueMatches.forEach(venue => entities.push(venue));
-    }
-    
-    return entities;
-  } catch (error) {
-    console.error('Error extracting entities:', error);
-    return [];
+  const data = await invokeEdgeWithFallback<any>('google-nlp', { text }, () =>
+    localExtractEntities(text)
+  );
+
+  if (Array.isArray(data)) {
+    return data.map((e) => (typeof e === 'string' ? e : e?.name)).filter(Boolean);
   }
+  if (data && typeof data === 'object' && Array.isArray(data.entities)) {
+    const names = data.entities
+      .map((e: any) => (typeof e === 'string' ? e : e?.name))
+      .filter(Boolean);
+    return names.length ? names : localExtractEntities(text);
+  }
+  return localExtractEntities(text);
 };

--- a/src/services/VertexAI/safety.ts
+++ b/src/services/VertexAI/safety.ts
@@ -1,28 +1,24 @@
 
 /**
- * Content safety services using Vertex AI
+ * Content safety services routed through the `content-safety` edge function.
  */
-import { supabase } from '@/integrations/supabase/client';
+import { invokeEdgeWithFallback } from '@/services/edge/invokeEdge';
 
 /**
- * Evaluate if content is safe using Vertex AI Content Safety API
+ * Evaluate if content is safe. Defaults to safe when the edge function is
+ * unavailable so the chat is never blocked.
  */
-export async function checkContentSafety(content: string): Promise<{safe: boolean, reasons?: string[]}> {
-  try {
-    const { data, error } = await supabase.functions.invoke('content-safety', {
-      body: { content }
-    });
-    
-    if (error) {
-      console.error('Error calling content safety function:', error);
-      // Default to safe if we can't check
-      return { safe: true };
-    }
-    
+export async function checkContentSafety(
+  content: string
+): Promise<{ safe: boolean; reasons?: string[] }> {
+  const data = await invokeEdgeWithFallback<{ safe: boolean; reasons?: string[] }>(
+    'content-safety',
+    { content },
+    () => ({ safe: true })
+  );
+
+  if (data && typeof data === 'object' && typeof data.safe === 'boolean') {
     return data;
-  } catch (error) {
-    console.error('Error in checkContentSafety:', error);
-    // Default to safe if we can't check
-    return { safe: true };
   }
+  return { safe: true };
 }

--- a/src/services/VertexAI/speech.ts
+++ b/src/services/VertexAI/speech.ts
@@ -1,65 +1,62 @@
 
 /**
- * Speech services using Google's Text-to-Speech API
+ * Speech services routed through edge functions with silent text-only degrade.
  */
-import { supabase } from '@/integrations/supabase/client';
-import { toast } from 'sonner';
+import { invokeEdgeWithFallback } from '@/services/edge/invokeEdge';
 import { TextToSpeechOptions, DEFAULT_MALE_VOICE } from './types';
 
-/**
- * Generate speech from text using Google Text-to-Speech API
- */
-export async function textToSpeech(text: string, options: TextToSpeechOptions = {}): Promise<string | null> {
-  try {
-    console.log('Converting text to speech with Google TTS:', text.substring(0, 50) + '...');
-    
-    const { data, error } = await supabase.functions.invoke('google-tts', {
-      body: { 
-        text,
-        voice: options.voice || DEFAULT_MALE_VOICE, // Use male voice by default
-        speakingRate: options.speakingRate || 1.0,
-        pitch: options.pitch || 0
-      }
-    });
-    
-    if (error) {
-      console.error('Error calling Google TTS function:', error);
-      throw new Error(`Text-to-speech conversion failed: ${error.message}`);
-    }
-    
-    if (!data || !data.audioContent) {
-      throw new Error('No audio content received from Google TTS');
-    }
-    
-    return data.audioContent;
-  } catch (error) {
-    console.error('Error in textToSpeech:', error);
-    toast.error('Failed to generate speech. Using browser voice instead.');
-    return null;
+function asAudio(data: unknown): string | null {
+  if (typeof data === 'string' && data.trim()) return data;
+  if (data && typeof data === 'object') {
+    const obj = data as Record<string, any>;
+    return obj.audioContent || obj.audio || obj.base64 || null;
   }
+  return null;
 }
 
 /**
- * Transcribe speech to text using Google Speech-to-Text API
+ * Generate speech from text. Tries `eleven-labs-tts`, then `google-tts`, and
+ * returns null (text-only) when no audio backend is available.
+ */
+export async function textToSpeech(
+  text: string,
+  options: TextToSpeechOptions = {}
+): Promise<string | null> {
+  const data = await invokeEdgeWithFallback<unknown>(
+    'eleven-labs-tts',
+    { text, voice: options.voice || DEFAULT_MALE_VOICE },
+    async () =>
+      invokeEdgeWithFallback<unknown>(
+        'google-tts',
+        {
+          text,
+          voice: options.voice || DEFAULT_MALE_VOICE,
+          speakingRate: options.speakingRate || 1.0,
+          pitch: options.pitch || 0,
+        },
+        () => null
+      )
+  );
+
+  return asAudio(data);
+}
+
+/**
+ * Transcribe speech to text via `google-stt`. Returns null when unavailable so
+ * the caller can fall back to browser speech recognition or text input.
  */
 export async function speechToText(audioBase64: string): Promise<string | null> {
-  try {
-    const { data, error } = await supabase.functions.invoke('google-stt', {
-      body: { audio: audioBase64 }
-    });
-    
-    if (error) {
-      console.error('Error calling Google STT function:', error);
-      throw new Error(`Speech-to-text conversion failed: ${error.message}`);
-    }
-    
-    if (!data || !data.transcript) {
-      throw new Error('No transcript received from Google STT');
-    }
-    
-    return data.transcript;
-  } catch (error) {
-    console.error('Error in speechToText:', error);
-    return null;
+  const data = await invokeEdgeWithFallback<unknown>(
+    'google-stt',
+    { audio: audioBase64 },
+    () => null
+  );
+
+  if (typeof data === 'string' && data.trim()) return data;
+  if (data && typeof data === 'object') {
+    const obj = data as Record<string, any>;
+    const transcript = obj.transcript || obj.text;
+    if (typeof transcript === 'string' && transcript.trim()) return transcript;
   }
+  return null;
 }

--- a/src/services/VertexAI/text.ts
+++ b/src/services/VertexAI/text.ts
@@ -2,79 +2,78 @@
 /**
  * Text generation services using Vertex AI
  */
-import { supabase } from '@/integrations/supabase/client';
-import { toast } from 'sonner';
+import { invokeEdgeWithFallback } from '@/services/edge/invokeEdge';
 import { GenerateTextOptions } from './types';
 
+function asText(data: unknown, fallback: string): string {
+  if (typeof data === 'string' && data.trim()) return data;
+  if (data && typeof data === 'object') {
+    const obj = data as Record<string, any>;
+    const text =
+      obj.text || obj.response || obj.content || obj.choices?.[0]?.message?.content;
+    if (typeof text === 'string' && text.trim()) return text;
+  }
+  return fallback;
+}
+
 /**
- * Generate text using Vertex AI
+ * Generate text. Routes through the `vertex-ai` edge function and falls back
+ * to `openai-chat`, then a safe canned message so the chat never breaks.
  */
 export async function generateText(
-  prompt: string, 
-  history: Array<{sender: 'user' | 'ai', text: string}> = [],
+  prompt: string,
+  history: Array<{ sender: 'user' | 'ai'; text: string }> = [],
   options: GenerateTextOptions = {}
 ): Promise<string> {
-  try {
-    console.log(`Generating text with Vertex AI for prompt: "${prompt.substring(0, 50)}..."`);
-    
-    const { data, error } = await supabase.functions.invoke('vertex-ai', {
-      body: { 
-        prompt, 
-        history,
-        model: options.model || 'gemini-1.5-pro',
-        maxTokens: options.maxTokens || 2048,
-        temperature: options.temperature || 0.7,
-        mode: options.mode || 'default',
-        safetySettings: options.safetySettings
-      }
-    });
-    
-    if (error) {
-      console.error('Error calling Vertex AI function:', error);
-      throw new Error(`Vertex AI text generation failed: ${error.message}`);
-    }
-    
-    if (!data || !data.text) {
-      throw new Error('No text received from Vertex AI');
-    }
-    
-    return data.text;
-  } catch (error) {
-    console.error('Error in generateText:', error);
-    toast.error('AI text generation encountered an error');
-    return "I'm having trouble generating a response right now. Please try again later.";
-  }
+  const fallbackText =
+    "I'm here to help you find great places and things to do. Tell me what you're in the mood for and where, and I'll dig up some real venues.";
+
+  const data = await invokeEdgeWithFallback<unknown>(
+    'vertex-ai',
+    {
+      prompt,
+      history,
+      model: options.model || 'gemini-1.5-pro',
+      maxTokens: options.maxTokens || 2048,
+      temperature: options.temperature || 0.7,
+      mode: options.mode || 'default',
+      safetySettings: options.safetySettings,
+    },
+    async () =>
+      invokeEdgeWithFallback<unknown>(
+        'openai-chat',
+        { prompt, history, mode: options.mode || 'default' },
+        () => fallbackText
+      )
+  );
+
+  return asText(data, fallbackText);
 }
 
 /**
  * Generate factual information using Vertex AI search capabilities
  */
 export async function searchWithAI(query: string, categories?: string[]): Promise<string> {
-  try {
-    console.log(`Searching with Vertex AI: "${query.substring(0, 50)}..."`);
-    
-    const { data, error } = await supabase.functions.invoke('vertex-ai', {
-      body: { 
-        prompt: query,
-        mode: 'search',
-        searchMode: true,
-        categories: categories || [],
-        temperature: 0.1 // Low temperature for factual responses
-      }
-    });
-    
-    if (error) {
-      console.error('Error calling Vertex AI search:', error);
-      throw new Error(`Vertex AI search failed: ${error.message}`);
-    }
-    
-    if (!data || !data.text) {
-      throw new Error('No search results received from Vertex AI');
-    }
-    
-    return data.text;
-  } catch (error) {
-    console.error('Error in searchWithAI:', error);
-    return "I couldn't find specific information about that. Could you try rephrasing your question?";
-  }
+  const fallbackText =
+    "I couldn't find specific information about that. Could you try rephrasing your question, or tell me a city to search?";
+
+  // NL/online search -> perplexity-search, falling back to vertex-ai search mode.
+  const data = await invokeEdgeWithFallback<unknown>(
+    'perplexity-search',
+    { query, categories: categories || [] },
+    async () =>
+      invokeEdgeWithFallback<unknown>(
+        'vertex-ai',
+        {
+          prompt: query,
+          mode: 'search',
+          searchMode: true,
+          categories: categories || [],
+          temperature: 0.1,
+        },
+        () => fallbackText
+      )
+  );
+
+  return asText(data, fallbackText);
 }

--- a/src/services/data/commentsRepo.ts
+++ b/src/services/data/commentsRepo.ts
@@ -1,0 +1,68 @@
+import type { Comment } from "@/types";
+import { mockComments } from "@/mock/comments";
+import { table, withFallback } from "./config";
+import { mapProfileToUser } from "./profilesRepo";
+
+const COMMENT_SELECT = "*, author:profiles!comments_author_id_fkey(*)";
+
+function mapRowToComment(row: any): Comment {
+  const user = row.author ? mapProfileToUser(row.author) : undefined;
+  return {
+    id: row.id,
+    postId: row.post_id,
+    contentId: row.post_id,
+    userId: row.author_id,
+    user,
+    author: user,
+    content: row.content,
+    body: row.content,
+    timestamp: row.created_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    likes: row.likes_count ?? 0,
+    parentId: row.parent_id ?? undefined,
+    status: "published",
+    engagement: { likes: row.likes_count ?? 0, replies: 0, reactions: [] },
+    moderation: { status: "approved", flags: [] },
+  } as Comment;
+}
+
+export const commentsRepo = {
+  async getForPost(postId: string): Promise<Comment[]> {
+    return withFallback<Comment[]>(
+      "comments.getForPost",
+      async () => {
+        const { data, error } = await table("comments")
+          .select(COMMENT_SELECT)
+          .eq("post_id", postId)
+          .order("created_at", { ascending: true });
+        return { data: (data ?? []).map(mapRowToComment), error };
+      },
+      () => mockComments.filter((c) => c.postId === postId),
+    );
+  },
+
+  async create(input: {
+    postId: string;
+    authorId: string;
+    content: string;
+    parentId?: string;
+  }): Promise<Comment> {
+    const { data, error } = await table("comments")
+      .insert({
+        post_id: input.postId,
+        author_id: input.authorId,
+        content: input.content,
+        parent_id: input.parentId ?? null,
+      })
+      .select(COMMENT_SELECT)
+      .single();
+    if (error) throw error;
+    return mapRowToComment(data);
+  },
+
+  async remove(id: string): Promise<void> {
+    const { error } = await table("comments").delete().eq("id", id);
+    if (error) throw error;
+  },
+};

--- a/src/services/data/config.ts
+++ b/src/services/data/config.ts
@@ -1,0 +1,60 @@
+import { supabase } from "@/integrations/supabase/client";
+
+/**
+ * Mock-fallback switch for the whole data layer.
+ *
+ * Defaults to ON so the app renders full demo content even against an empty or
+ * unauthenticated database. Set `VITE_USE_MOCK_FALLBACK=false` to force real-data-only
+ * mode (useful for verifying persistence end-to-end).
+ */
+export const USE_MOCK_FALLBACK =
+  (import.meta.env.VITE_USE_MOCK_FALLBACK ?? "true") !== "false";
+
+/**
+ * Untyped table accessor. The generated Supabase types in
+ * src/integrations/supabase/types.ts don't yet include the core social tables added by
+ * the 20260601120000_core_social_schema migration. Until `supabase gen types` is re-run
+ * against the migrated database, repositories use this accessor to query the new tables
+ * without TypeScript complaining about unknown table names.
+ */
+export const table = (name: string) => (supabase as any).from(name);
+
+export { supabase };
+
+type QueryResult<T> = { data: T | null; error: unknown };
+
+/**
+ * Run a Supabase query and transparently fall back to mock data when the query errors
+ * (network/RLS/missing table) or returns nothing — but only while USE_MOCK_FALLBACK is
+ * on. With it off, errors propagate so we can verify real persistence.
+ *
+ * @param label    short identifier for logging
+ * @param query    function returning a Supabase query result ({ data, error })
+ * @param mock      lazily-evaluated mock value used as the fallback
+ * @param treatEmptyAsMissing  when true (default), an empty array also triggers fallback
+ */
+export async function withFallback<T>(
+  label: string,
+  query: () => Promise<QueryResult<T>>,
+  mock: () => T | Promise<T>,
+  treatEmptyAsMissing = true,
+): Promise<T> {
+  try {
+    const { data, error } = await query();
+    if (error) throw error;
+
+    const isEmpty =
+      data == null || (Array.isArray(data) && data.length === 0 && treatEmptyAsMissing);
+
+    if (isEmpty && USE_MOCK_FALLBACK) {
+      return await mock();
+    }
+    return (data ?? (await mock())) as T;
+  } catch (err) {
+    if (USE_MOCK_FALLBACK) {
+      console.warn(`[data:${label}] falling back to mock:`, err);
+      return await mock();
+    }
+    throw err;
+  }
+}

--- a/src/services/data/index.ts
+++ b/src/services/data/index.ts
@@ -15,3 +15,8 @@ export { commentsRepo } from "./commentsRepo";
 export { locationsRepo, mapRowToLocation } from "./locationsRepo";
 export { tripsRepo } from "./tripsRepo";
 export type { TripRecord } from "./tripsRepo";
+export { messagesRepo } from "./messagesRepo";
+export type { ChatConversation, ChatMessage } from "./messagesRepo";
+export { notificationsRepo } from "./notificationsRepo";
+export type { AppNotification } from "./notificationsRepo";
+export { preferencesRepo } from "./preferencesRepo";

--- a/src/services/data/index.ts
+++ b/src/services/data/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Data-access layer for Vibe Right Now.
+ *
+ * Every repository reads from the Supabase backend and transparently falls back to the
+ * `src/mock/*` data when the query errors or returns nothing (gated by
+ * VITE_USE_MOCK_FALLBACK). This is the seam that lets the app run fully whether or not
+ * the database is populated / the user is signed in. Feature code should import repos
+ * from here rather than touching `src/mock/*` or the supabase client directly.
+ */
+export { USE_MOCK_FALLBACK, withFallback, table, supabase } from "./config";
+export { profilesRepo, mapProfileToUser } from "./profilesRepo";
+export { postsRepo, mapRowToPost } from "./postsRepo";
+export type { CreatePostInput } from "./postsRepo";
+export { commentsRepo } from "./commentsRepo";
+export { locationsRepo, mapRowToLocation } from "./locationsRepo";
+export { tripsRepo } from "./tripsRepo";
+export type { TripRecord } from "./tripsRepo";

--- a/src/services/data/locationsRepo.ts
+++ b/src/services/data/locationsRepo.ts
@@ -1,0 +1,93 @@
+import type { Location } from "@/types";
+import { mockLocations } from "@/mock/locations";
+import { table, withFallback } from "./config";
+import { invokeEdgeWithFallback } from "@/services/edge/invokeEdge";
+
+/** Map a `locations` DB row to the app's Location type. */
+export function mapRowToLocation(row: any): Location {
+  return {
+    id: row.id,
+    name: row.name,
+    address: row.address ?? "",
+    city: row.city ?? "",
+    state: row.state ?? undefined,
+    country: row.country ?? undefined,
+    lat: row.lat,
+    lng: row.lng,
+    type: row.category ?? "venue",
+    verified: false,
+  } as Location;
+}
+
+export const locationsRepo = {
+  async getById(id: string): Promise<Location | null> {
+    return withFallback<Location | null>(
+      "locations.getById",
+      async () => {
+        const { data, error } = await table("locations").select("*").eq("id", id).maybeSingle();
+        return { data: data ? mapRowToLocation(data) : null, error };
+      },
+      () => mockLocations.find((l) => l.id === id) ?? null,
+      false,
+    );
+  },
+
+  /**
+   * Text search. Tries the google-places edge function first (real venue data), then the
+   * locations table, and finally a local filter over mock venues — so search always
+   * returns something even with no API keys configured.
+   */
+  async search(query: string, limit = 20): Promise<Location[]> {
+    const q = query.trim().toLowerCase();
+    return invokeEdgeWithFallback<Location[]>(
+      "google-places",
+      { action: "textSearch", query },
+      async () =>
+        withFallback<Location[]>(
+          "locations.search",
+          async () => {
+            const { data, error } = await table("locations")
+              .select("*")
+              .ilike("name", `%${query}%`)
+              .limit(limit);
+            return { data: (data ?? []).map(mapRowToLocation), error };
+          },
+          () =>
+            mockLocations
+              .filter(
+                (l) =>
+                  l.name.toLowerCase().includes(q) ||
+                  l.city?.toLowerCase().includes(q) ||
+                  l.tags?.some((t) => t.toLowerCase().includes(q)),
+              )
+              .slice(0, limit),
+        ),
+    );
+  },
+
+  async nearby(_lat: number, _lng: number, limit = 20): Promise<Location[]> {
+    return withFallback<Location[]>(
+      "locations.nearby",
+      async () => {
+        const { data, error } = await table("locations").select("*").limit(limit);
+        return { data: (data ?? []).map(mapRowToLocation), error };
+      },
+      () => mockLocations.slice(0, limit),
+    );
+  },
+
+  async byCity(city: string, limit = 30): Promise<Location[]> {
+    const c = city.trim().toLowerCase();
+    return withFallback<Location[]>(
+      "locations.byCity",
+      async () => {
+        const { data, error } = await table("locations")
+          .select("*")
+          .ilike("city", `%${city}%`)
+          .limit(limit);
+        return { data: (data ?? []).map(mapRowToLocation), error };
+      },
+      () => mockLocations.filter((l) => l.city?.toLowerCase().includes(c)).slice(0, limit),
+    );
+  },
+};

--- a/src/services/data/messagesRepo.ts
+++ b/src/services/data/messagesRepo.ts
@@ -1,0 +1,144 @@
+import { mockVenueConversations } from "@/components/messaging/mockVenueData";
+import { table, supabase, withFallback } from "./config";
+
+/** Normalized conversation/message shapes (compatible with the venue messaging UI). */
+export interface ChatMessage {
+  id: string;
+  content: string;
+  timestamp: string;
+  senderId: string;
+  senderName: string;
+  senderAvatar: string;
+  senderType: "user" | "venue";
+  messageType?: string;
+}
+
+export interface ChatConversation {
+  id: string;
+  venueId: string;
+  venueName: string;
+  venueAvatar: string;
+  venueType?: string;
+  unreadCount: number;
+  isActive: boolean;
+  responseTime?: string;
+  messages: ChatMessage[];
+  lastMessage?: ChatMessage;
+}
+
+function mapRowToMessage(row: any): ChatMessage {
+  return {
+    id: row.id,
+    content: row.content,
+    timestamp: row.created_at,
+    senderId: row.sender_id ?? "",
+    senderName: row.sender_type === "venue" ? "Venue" : "You",
+    senderAvatar: "",
+    senderType: row.sender_type ?? "user",
+    messageType: row.message_type,
+  };
+}
+
+export const messagesRepo = {
+  async listConversations(userId: string): Promise<ChatConversation[]> {
+    return withFallback<ChatConversation[]>(
+      "messages.listConversations",
+      async () => {
+        const { data, error } = await table("conversations")
+          .select("*, messages(*)")
+          .eq("created_by", userId)
+          .order("updated_at", { ascending: false });
+        const convs: ChatConversation[] = (data ?? []).map((c: any) => {
+          const messages = (c.messages ?? [])
+            .map(mapRowToMessage)
+            .sort((a: ChatMessage, b: ChatMessage) => a.timestamp.localeCompare(b.timestamp));
+          return {
+            id: c.id,
+            venueId: c.venue_id ?? c.thread_key,
+            venueName: c.venue_name ?? c.title ?? "Conversation",
+            venueAvatar: c.venue_avatar ?? "",
+            venueType: undefined,
+            unreadCount: (c.messages ?? []).filter(
+              (m: any) => m.sender_type === "venue" && !m.read,
+            ).length,
+            isActive: true,
+            responseTime: undefined,
+            messages,
+            lastMessage: messages[messages.length - 1],
+          };
+        });
+        return { data: convs, error };
+      },
+      () => mockVenueConversations as unknown as ChatConversation[],
+    );
+  },
+
+  async sendMessage(input: {
+    conversationId: string;
+    senderId: string;
+    content: string;
+    senderType?: "user" | "venue";
+    messageType?: string;
+  }): Promise<ChatMessage> {
+    const { data, error } = await table("messages")
+      .insert({
+        conversation_id: input.conversationId,
+        sender_id: input.senderId,
+        sender_type: input.senderType ?? "user",
+        message_type: input.messageType ?? "general",
+        content: input.content,
+      })
+      .select("*")
+      .single();
+    if (error) throw error;
+    return mapRowToMessage(data);
+  },
+
+  /** Find-or-create a conversation thread (e.g. for a venue) for the given user. */
+  async ensureConversation(input: {
+    userId: string;
+    threadKey: string;
+    venueId?: string;
+    venueName?: string;
+    venueAvatar?: string;
+  }): Promise<string> {
+    const existing = await table("conversations")
+      .select("id")
+      .eq("created_by", input.userId)
+      .eq("thread_key", input.threadKey)
+      .maybeSingle();
+    if (existing?.data?.id) return existing.data.id;
+    const { data, error } = await table("conversations")
+      .insert({
+        created_by: input.userId,
+        thread_key: input.threadKey,
+        venue_id: input.venueId ?? null,
+        venue_name: input.venueName ?? null,
+        venue_avatar: input.venueAvatar ?? null,
+      })
+      .select("id")
+      .single();
+    if (error) throw error;
+    return data.id;
+  },
+
+  /** Subscribe to new messages in a conversation via Supabase Realtime. */
+  subscribe(conversationId: string, onMessage: (m: ChatMessage) => void) {
+    const channel = supabase
+      .channel(`messages:${conversationId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "messages",
+          filter: `conversation_id=eq.${conversationId}`,
+        },
+        (payload: any) => onMessage(mapRowToMessage(payload.new)),
+      )
+      .subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  },
+};

--- a/src/services/data/notificationsRepo.ts
+++ b/src/services/data/notificationsRepo.ts
@@ -1,0 +1,53 @@
+import { table, withFallback } from "./config";
+
+export interface AppNotification {
+  id: string;
+  type: string;
+  title: string;
+  body?: string;
+  link?: string;
+  read: boolean;
+  createdAt: string;
+}
+
+function mapRow(row: any): AppNotification {
+  return {
+    id: row.id,
+    type: row.type ?? "info",
+    title: row.title,
+    body: row.body ?? undefined,
+    link: row.link ?? undefined,
+    read: row.read ?? false,
+    createdAt: row.created_at,
+  };
+}
+
+export const notificationsRepo = {
+  async list(userId: string): Promise<AppNotification[]> {
+    return withFallback<AppNotification[]>(
+      "notifications.list",
+      async () => {
+        const { data, error } = await table("notifications")
+          .select("*")
+          .eq("user_id", userId)
+          .order("created_at", { ascending: false })
+          .limit(50);
+        return { data: (data ?? []).map(mapRow), error };
+      },
+      () => [],
+    );
+  },
+
+  async markRead(id: string): Promise<void> {
+    const { error } = await table("notifications").update({ read: true }).eq("id", id);
+    if (error) throw error;
+  },
+
+  async markAllRead(userId: string): Promise<void> {
+    const { error } = await table("notifications")
+      .update({ read: true })
+      .eq("user_id", userId)
+      .eq("read", false);
+    if (error) throw error;
+  },
+};

--- a/src/services/data/postsRepo.ts
+++ b/src/services/data/postsRepo.ts
@@ -1,0 +1,176 @@
+import type { Post } from "@/types";
+import { mockPosts } from "@/mock/posts";
+import { supabase, table, withFallback, USE_MOCK_FALLBACK } from "./config";
+import { mapProfileToUser } from "./profilesRepo";
+
+const POST_SELECT = "*, author:profiles!posts_author_id_fkey(*)";
+
+/** Map a `posts` DB row (optionally with joined author) to the app's Post type. */
+export function mapRowToPost(row: any): Post {
+  const media = Array.isArray(row.media) ? row.media : [];
+  return {
+    id: row.id,
+    userId: row.author_id,
+    user: row.author ? mapProfileToUser(row.author) : undefined,
+    content: row.content ?? "",
+    media,
+    vibes: row.vibe_tags ?? [],
+    vibeTags: row.vibe_tags ?? [],
+    timestamp: row.created_at,
+    likes: row.likes_count ?? 0,
+    comments: row.comments_count ?? 0,
+    saved: false,
+    isVenuePost: row.is_venue_post ?? false,
+    isPinned: false,
+    visibility: row.visibility ?? "public",
+    location: row.location_id
+      ? {
+          id: row.location_id,
+          name: row.location_name ?? "",
+          city: row.location_city ?? "",
+          state: row.location_state ?? "",
+        }
+      : undefined,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  } as Post;
+}
+
+export interface CreatePostInput {
+  authorId: string;
+  content: string;
+  media?: unknown[];
+  vibeTags?: string[];
+  visibility?: "public" | "friends" | "private";
+  location?: { id?: string; name?: string; city?: string; state?: string };
+  isVenuePost?: boolean;
+}
+
+export const postsRepo = {
+  async getFeed(limit = 50): Promise<Post[]> {
+    return withFallback<Post[]>(
+      "posts.getFeed",
+      async () => {
+        const { data, error } = await table("posts")
+          .select(POST_SELECT)
+          .eq("visibility", "public")
+          .order("created_at", { ascending: false })
+          .limit(limit);
+        return { data: (data ?? []).map(mapRowToPost), error };
+      },
+      () => mockPosts,
+    );
+  },
+
+  async getByUser(userId: string): Promise<Post[]> {
+    return withFallback<Post[]>(
+      "posts.getByUser",
+      async () => {
+        const { data, error } = await table("posts")
+          .select(POST_SELECT)
+          .eq("author_id", userId)
+          .order("created_at", { ascending: false });
+        return { data: (data ?? []).map(mapRowToPost), error };
+      },
+      () => mockPosts.filter((p) => p.userId === userId || p.user?.id === userId),
+    );
+  },
+
+  async getByVenue(locationId: string): Promise<Post[]> {
+    return withFallback<Post[]>(
+      "posts.getByVenue",
+      async () => {
+        const { data, error } = await table("posts")
+          .select(POST_SELECT)
+          .eq("location_id", locationId)
+          .order("created_at", { ascending: false });
+        return { data: (data ?? []).map(mapRowToPost), error };
+      },
+      () => mockPosts.filter((p) => p.location?.id === locationId),
+    );
+  },
+
+  async create(input: CreatePostInput): Promise<Post> {
+    const { data, error } = await table("posts")
+      .insert({
+        author_id: input.authorId,
+        content: input.content,
+        media: input.media ?? [],
+        vibe_tags: input.vibeTags ?? [],
+        visibility: input.visibility ?? "public",
+        is_venue_post: input.isVenuePost ?? false,
+        location_id: input.location?.id ?? null,
+        location_name: input.location?.name ?? null,
+        location_city: input.location?.city ?? null,
+        location_state: input.location?.state ?? null,
+      })
+      .select(POST_SELECT)
+      .single();
+    if (error) throw error;
+    return mapRowToPost(data);
+  },
+
+  async remove(id: string): Promise<void> {
+    const { error } = await table("posts").delete().eq("id", id);
+    if (error) throw error;
+  },
+
+  async toggleLike(postId: string, userId: string, liked: boolean): Promise<void> {
+    if (liked) {
+      const { error } = await table("post_likes").insert({ post_id: postId, user_id: userId });
+      if (error && error.code !== "23505") throw error; // ignore duplicate
+    } else {
+      const { error } = await table("post_likes")
+        .delete()
+        .eq("post_id", postId)
+        .eq("user_id", userId);
+      if (error) throw error;
+    }
+  },
+
+  async toggleSave(postId: string, userId: string, saved: boolean): Promise<void> {
+    if (saved) {
+      const { error } = await table("saved_posts").insert({ post_id: postId, user_id: userId });
+      if (error && error.code !== "23505") throw error;
+    } else {
+      const { error } = await table("saved_posts")
+        .delete()
+        .eq("post_id", postId)
+        .eq("user_id", userId);
+      if (error) throw error;
+    }
+  },
+
+  async getSaved(userId: string): Promise<Post[]> {
+    return withFallback<Post[]>(
+      "posts.getSaved",
+      async () => {
+        const { data, error } = await table("saved_posts")
+          .select(`post:posts(${POST_SELECT})`)
+          .eq("user_id", userId);
+        const posts = (data ?? []).map((r: any) => mapRowToPost(r.post)).filter(Boolean);
+        return { data: posts, error };
+      },
+      () => mockPosts.filter((p) => p.saved),
+    );
+  },
+
+  /** Upload post media to the `post-media` storage bucket and return public URLs. */
+  async uploadMedia(userId: string, files: File[]): Promise<string[]> {
+    const urls: string[] = [];
+    for (const file of files) {
+      const path = `${userId}/${Date.now()}-${file.name}`;
+      const { error } = await supabase.storage.from("post-media").upload(path, file);
+      if (error) {
+        if (USE_MOCK_FALLBACK) {
+          urls.push(URL.createObjectURL(file));
+          continue;
+        }
+        throw error;
+      }
+      const { data } = supabase.storage.from("post-media").getPublicUrl(path);
+      urls.push(data.publicUrl);
+    }
+    return urls;
+  },
+};

--- a/src/services/data/preferencesRepo.ts
+++ b/src/services/data/preferencesRepo.ts
@@ -1,0 +1,64 @@
+import { table, USE_MOCK_FALLBACK } from "./config";
+
+const LS_KEY = "vibe-user-preferences";
+
+function readLocal(): Record<string, unknown> {
+  try {
+    return JSON.parse(localStorage.getItem(LS_KEY) ?? "{}");
+  } catch {
+    return {};
+  }
+}
+
+function writeLocal(prefs: Record<string, unknown>) {
+  try {
+    localStorage.setItem(LS_KEY, JSON.stringify(prefs));
+  } catch {
+    /* ignore */
+  }
+}
+
+export const preferencesRepo = {
+  /** Get the user's preferences blob. Falls back to localStorage when signed out. */
+  async get(userId: string | null): Promise<Record<string, unknown>> {
+    if (!userId) return readLocal();
+    try {
+      const { data, error } = await table("user_preferences")
+        .select("preferences")
+        .eq("user_id", userId)
+        .maybeSingle();
+      if (error) throw error;
+      return data?.preferences ?? readLocal();
+    } catch (err) {
+      if (USE_MOCK_FALLBACK) {
+        console.warn("[data:preferences.get] falling back to localStorage:", err);
+        return readLocal();
+      }
+      throw err;
+    }
+  },
+
+  /** Merge-update preferences. Persists to localStorage too so it survives sign-out. */
+  async update(
+    userId: string | null,
+    patch: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const merged = { ...readLocal(), ...patch };
+    writeLocal(merged);
+    if (!userId) return merged;
+    try {
+      const { data, error } = await table("user_preferences")
+        .upsert({ user_id: userId, preferences: merged }, { onConflict: "user_id" })
+        .select("preferences")
+        .maybeSingle();
+      if (error) throw error;
+      return data?.preferences ?? merged;
+    } catch (err) {
+      if (USE_MOCK_FALLBACK) {
+        console.warn("[data:preferences.update] persisted to localStorage only:", err);
+        return merged;
+      }
+      throw err;
+    }
+  },
+};

--- a/src/services/data/profilesRepo.ts
+++ b/src/services/data/profilesRepo.ts
@@ -1,0 +1,99 @@
+import type { User } from "@/types";
+import { mockUsers, getUserById, getUserByUsername } from "@/mock/users";
+import { table, withFallback } from "./config";
+
+/** Map a `profiles` DB row to the app's rich User type. */
+export function mapProfileToUser(row: any): User {
+  return {
+    id: row.id,
+    username: row.username ?? "",
+    displayName: row.display_name ?? row.name ?? row.username,
+    name: row.name ?? row.display_name ?? row.username ?? "",
+    email: row.email ?? undefined,
+    avatar: row.avatar_url ?? undefined,
+    bio: row.bio ?? undefined,
+    verified: row.verified ?? false,
+    isPrivate: row.is_private ?? false,
+    createdAt: row.created_at ?? undefined,
+    updatedAt: row.updated_at ?? undefined,
+  };
+}
+
+function mockUserToUser(u: any): User {
+  return {
+    id: u.id,
+    username: u.username,
+    displayName: u.name ?? u.username,
+    name: u.name ?? u.username,
+    avatar: u.avatar,
+    bio: u.bio,
+    verified: u.verified,
+    followers: u.followers,
+    following: u.following,
+    posts: u.posts,
+  };
+}
+
+export const profilesRepo = {
+  async getById(id: string): Promise<User | null> {
+    return withFallback<User | null>(
+      "profiles.getById",
+      async () => {
+        const { data, error } = await table("profiles").select("*").eq("id", id).maybeSingle();
+        return { data: data ? mapProfileToUser(data) : null, error };
+      },
+      () => {
+        const u = getUserById(id);
+        return u ? mockUserToUser(u) : null;
+      },
+      false,
+    );
+  },
+
+  async getByUsername(username: string): Promise<User | null> {
+    return withFallback<User | null>(
+      "profiles.getByUsername",
+      async () => {
+        const { data, error } = await table("profiles")
+          .select("*")
+          .eq("username", username)
+          .maybeSingle();
+        return { data: data ? mapProfileToUser(data) : null, error };
+      },
+      () => {
+        const u = getUserByUsername(username);
+        return u ? mockUserToUser(u) : null;
+      },
+      false,
+    );
+  },
+
+  /** Persist profile edits (ProfileBio save). Requires an authenticated session. */
+  async update(id: string, updates: Partial<User>): Promise<User | null> {
+    const payload: Record<string, unknown> = {};
+    if (updates.displayName !== undefined) payload.display_name = updates.displayName;
+    if (updates.name !== undefined) payload.name = updates.name;
+    if (updates.bio !== undefined) payload.bio = updates.bio;
+    if (updates.avatar !== undefined) payload.avatar_url = updates.avatar;
+    if (updates.isPrivate !== undefined) payload.is_private = updates.isPrivate;
+
+    const { data, error } = await table("profiles")
+      .update(payload)
+      .eq("id", id)
+      .select("*")
+      .maybeSingle();
+    if (error) throw error;
+    return data ? mapProfileToUser(data) : null;
+  },
+
+  async listSuggested(limit = 10): Promise<User[]> {
+    return withFallback<User[]>(
+      "profiles.listSuggested",
+      async () => {
+        const { data, error } = await table("profiles").select("*").limit(limit);
+        return { data: (data ?? []).map(mapProfileToUser), error };
+      },
+      () => mockUsers.slice(0, limit).map(mockUserToUser),
+    );
+  },
+};

--- a/src/services/data/tripsRepo.ts
+++ b/src/services/data/tripsRepo.ts
@@ -1,0 +1,99 @@
+import { table, withFallback } from "./config";
+
+export interface TripRecord {
+  id: string;
+  ownerId: string;
+  name: string;
+  description?: string;
+  startDate?: string;
+  endDate?: string;
+  coverImageUrl?: string;
+  createdAt?: string;
+}
+
+function mapRowToTrip(row: any): TripRecord {
+  return {
+    id: row.id,
+    ownerId: row.owner_id,
+    name: row.name,
+    description: row.description ?? undefined,
+    startDate: row.start_date ?? undefined,
+    endDate: row.end_date ?? undefined,
+    coverImageUrl: row.cover_image_url ?? undefined,
+    createdAt: row.created_at,
+  };
+}
+
+const mockTrips: TripRecord[] = [
+  { id: "demo-trip-1", ownerId: "1", name: "Weekend in Miami", description: "Beach + nightlife" },
+  { id: "demo-trip-2", ownerId: "1", name: "NYC Food Crawl", description: "Best eats in the city" },
+];
+
+export const tripsRepo = {
+  async listForUser(userId: string): Promise<TripRecord[]> {
+    return withFallback<TripRecord[]>(
+      "trips.listForUser",
+      async () => {
+        const { data, error } = await table("trips")
+          .select("*")
+          .or(`owner_id.eq.${userId}`)
+          .order("created_at", { ascending: false });
+        return { data: (data ?? []).map(mapRowToTrip), error };
+      },
+      () => mockTrips,
+    );
+  },
+
+  async getById(id: string): Promise<TripRecord | null> {
+    return withFallback<TripRecord | null>(
+      "trips.getById",
+      async () => {
+        const { data, error } = await table("trips").select("*").eq("id", id).maybeSingle();
+        return { data: data ? mapRowToTrip(data) : null, error };
+      },
+      () => mockTrips.find((t) => t.id === id) ?? mockTrips[0],
+      false,
+    );
+  },
+
+  async create(input: {
+    ownerId: string;
+    name: string;
+    description?: string;
+    startDate?: string;
+    endDate?: string;
+  }): Promise<TripRecord> {
+    const { data, error } = await table("trips")
+      .insert({
+        owner_id: input.ownerId,
+        name: input.name,
+        description: input.description ?? null,
+        start_date: input.startDate ?? null,
+        end_date: input.endDate ?? null,
+      })
+      .select("*")
+      .single();
+    if (error) throw error;
+    // Owner is also a member.
+    await table("trip_members").insert({
+      trip_id: data.id,
+      user_id: input.ownerId,
+      role: "owner",
+    });
+    return mapRowToTrip(data);
+  },
+
+  async addMember(tripId: string, userId: string): Promise<void> {
+    const { error } = await table("trip_members").insert({
+      trip_id: tripId,
+      user_id: userId,
+      role: "member",
+    });
+    if (error && error.code !== "23505") throw error;
+  },
+
+  async remove(id: string): Promise<void> {
+    const { error } = await table("trips").delete().eq("id", id);
+    if (error) throw error;
+  },
+};

--- a/src/services/edge/index.ts
+++ b/src/services/edge/index.ts
@@ -1,0 +1,2 @@
+export { invokeEdge, invokeEdgeWithFallback } from './invokeEdge';
+export type { EdgeFunctionName } from './invokeEdge';

--- a/src/services/edge/invokeEdge.ts
+++ b/src/services/edge/invokeEdge.ts
@@ -1,0 +1,79 @@
+import { supabase } from "@/integrations/supabase/client";
+
+/**
+ * Thin, typed wrapper around `supabase.functions.invoke` for the project's edge
+ * functions (vertex-ai, openai-chat, perplexity-search, google-places, yelp-fusion,
+ * ticketmaster, eleven-labs-tts, google-stt, review-sentiment-analyzer, etc.).
+ *
+ * Every integration in the app should call edge functions through this helper so we
+ * get one consistent place for error handling and the mock-fallback convention used
+ * across the data layer (see src/services/data/config.ts).
+ *
+ * When no API keys are provisioned the edge function will error; callers should pass a
+ * `fallback` (or use `invokeEdgeWithFallback`) so the demo degrades gracefully to mock
+ * behaviour instead of throwing.
+ */
+export type EdgeFunctionName =
+  | "vertex-ai"
+  | "openai-chat"
+  | "openai-speech"
+  | "gemini-ai"
+  | "gemini-imagen"
+  | "perplexity-search"
+  | "google-places"
+  | "google-nlp"
+  | "google-stt"
+  | "google-tts"
+  | "get-maps-key"
+  | "yelp-fusion"
+  | "ticketmaster"
+  | "square-ai"
+  | "eleven-labs-tts"
+  | "generate-audio"
+  | "generate-audio-summary"
+  | "parse-venue-reviews"
+  | "review-sentiment-analyzer"
+  | "content-safety"
+  | "vector-search"
+  | "agent-protocol";
+
+export interface InvokeEdgeResult<T> {
+  data: T | null;
+  error: Error | null;
+}
+
+export async function invokeEdge<T = unknown>(
+  name: EdgeFunctionName,
+  body?: Record<string, unknown>,
+): Promise<InvokeEdgeResult<T>> {
+  try {
+    const { data, error } = await supabase.functions.invoke(name, {
+      body: body ?? {},
+    });
+    if (error) {
+      return { data: null, error: error as Error };
+    }
+    return { data: data as T, error: null };
+  } catch (err) {
+    return { data: null, error: err as Error };
+  }
+}
+
+/**
+ * Invoke an edge function and fall back to a local value when it errors (e.g. missing
+ * API key). Keeps the demo working with zero secrets configured.
+ */
+export async function invokeEdgeWithFallback<T>(
+  name: EdgeFunctionName,
+  body: Record<string, unknown> | undefined,
+  fallback: () => T | Promise<T>,
+): Promise<T> {
+  const { data, error } = await invokeEdge<T>(name, body);
+  if (error || data == null) {
+    if (error) {
+      console.warn(`[invokeEdge] "${name}" unavailable, using fallback:`, error.message);
+    }
+    return await fallback();
+  }
+  return data;
+}

--- a/src/services/posts/createPost.ts
+++ b/src/services/posts/createPost.ts
@@ -1,0 +1,99 @@
+import type { Post } from "@/types";
+import { postsRepo, table, type CreatePostInput } from "@/services/data";
+import { getCurrentUserId } from "./currentUser";
+
+export interface NewPostParams {
+  content: string;
+  files?: File[];
+  /** Pre-uploaded media URLs (e.g. captured camera webPaths). */
+  mediaUrls?: string[];
+  vibeTags?: string[];
+  visibility?: "public" | "friends" | "private";
+  location?: { id?: string; name?: string; city?: string; state?: string };
+  isVenuePost?: boolean;
+}
+
+export interface CheckInParams extends NewPostParams {
+  /** Optional free-form note saved on the check_ins row. */
+  note?: string;
+}
+
+/** Result returned when no user is signed in, so callers can prompt sign-in. */
+export class NotSignedInError extends Error {
+  constructor() {
+    super("not-signed-in");
+    this.name = "NotSignedInError";
+  }
+}
+
+/**
+ * Upload any provided files and create a post via the data layer.
+ * Throws {@link NotSignedInError} when nobody is signed in.
+ */
+export async function createPost(params: NewPostParams): Promise<Post> {
+  const userId = await getCurrentUserId();
+  if (!userId) throw new NotSignedInError();
+
+  const media: string[] = [...(params.mediaUrls ?? [])];
+  if (params.files && params.files.length > 0) {
+    const uploaded = await postsRepo.uploadMedia(userId, params.files);
+    media.push(...uploaded);
+  }
+
+  const input: CreatePostInput = {
+    authorId: userId,
+    content: params.content,
+    media,
+    vibeTags: params.vibeTags,
+    visibility: params.visibility ?? "public",
+    location: params.location,
+    isVenuePost: params.isVenuePost,
+  };
+
+  return postsRepo.create(input);
+}
+
+/**
+ * Perform a check-in: optionally upload a photo, write a `check_ins` row, and create a
+ * post referencing the venue. Returns the created post.
+ *
+ * Throws {@link NotSignedInError} when nobody is signed in. The `check_ins` insert is
+ * best-effort — if it fails (e.g. RLS / missing table in demo mode) we still create the
+ * post so the demo flow completes.
+ */
+export async function checkInAndPost(params: CheckInParams): Promise<Post> {
+  const userId = await getCurrentUserId();
+  if (!userId) throw new NotSignedInError();
+
+  // Upload photo(s) first so the URL can be stored on both the check-in and the post.
+  const media: string[] = [...(params.mediaUrls ?? [])];
+  if (params.files && params.files.length > 0) {
+    const uploaded = await postsRepo.uploadMedia(userId, params.files);
+    media.push(...uploaded);
+  }
+
+  // Write the check_ins row (best-effort).
+  try {
+    const { error } = await table("check_ins").insert({
+      user_id: userId,
+      location_id: params.location?.id ?? null,
+      location_name: params.location?.name ?? null,
+      photo_url: media[0] ?? null,
+      note: params.note ?? params.content ?? null,
+    });
+    if (error) console.warn("[check_ins] insert failed (continuing):", error);
+  } catch (err) {
+    console.warn("[check_ins] insert threw (continuing):", err);
+  }
+
+  // Create the post for the check-in.
+  return postsRepo.create({
+    authorId: userId,
+    content: params.content,
+    media,
+    vibeTags: params.vibeTags,
+    visibility: params.visibility ?? "public",
+    location: params.location,
+    isVenuePost: params.isVenuePost ?? true,
+  });
+}

--- a/src/services/posts/currentUser.ts
+++ b/src/services/posts/currentUser.ts
@@ -1,0 +1,29 @@
+import { supabase } from "@/services/data";
+import { useAppStore } from "@/store";
+
+/**
+ * Resolve the current user's id for persistence writes (like / save / delete / create
+ * / check-in).
+ *
+ * Order of resolution:
+ *  1. Supabase auth session (authoritative when signed in against a real backend).
+ *  2. The Zustand app store user (covers demo / mock sign-in flows).
+ *
+ * Returns `null` when nobody is signed in. Callers should treat `null` as "prompt the
+ * user to sign in" rather than throwing.
+ */
+export async function getCurrentUserId(): Promise<string | null> {
+  try {
+    const { data } = await supabase.auth.getUser();
+    if (data?.user?.id) return data.user.id;
+  } catch {
+    // ignore — fall through to store
+  }
+  const storeUser = useAppStore.getState().user;
+  return storeUser?.id ?? null;
+}
+
+/** Synchronous best-effort current user id from the Zustand store (no auth round-trip). */
+export function getCurrentUserIdSync(): string | null {
+  return useAppStore.getState().user?.id ?? null;
+}

--- a/src/services/sentimentAnalysisService.ts
+++ b/src/services/sentimentAnalysisService.ts
@@ -5,6 +5,7 @@
 // like Google Cloud Natural Language API, Azure Cognitive Services, etc.
 
 import { SentimentAnalysisResult, SentimentTheme, VenueSentimentAnalysis, PlatformSentimentSummary } from '@/types';
+import { invokeEdgeWithFallback } from '@/services/edge/invokeEdge';
 
 // Coffee shop specific themes and realistic data
 const COFFEE_SHOP_THEMES: SentimentTheme[] = [
@@ -142,18 +143,37 @@ const PLATFORM_SUMMARIES: PlatformSentimentSummary[] = [
   }
 ];
 
-// Mock function to analyze sentiment of a text
-export const analyzeSentiment = async (text: string): Promise<SentimentAnalysisResult> => {
-  // Simulate sentiment analysis for coffee shop context
+// Local mock sentiment used as the offline fallback.
+const mockAnalyzeSentiment = (text: string): SentimentAnalysisResult => {
   const score = Math.random() * 1.5 - 0.25; // Bias toward positive for coffee shop
   const magnitude = Math.random() * 0.8 + 0.2;
-
   return {
     score,
     magnitude,
     themes: COFFEE_SHOP_THEMES.slice(0, 3),
     summary: `Coffee shop sentiment analysis shows ${score > 0.3 ? 'positive' : score < -0.3 ? 'negative' : 'neutral'} customer feedback with focus on coffee quality and atmosphere.`,
   };
+};
+
+// Analyze sentiment of a text via the `review-sentiment-analyzer` edge function
+// (falling back to `google-nlp`, then local mock).
+export const analyzeSentiment = async (text: string): Promise<SentimentAnalysisResult> => {
+  const data = await invokeEdgeWithFallback<any>(
+    'review-sentiment-analyzer',
+    { text },
+    async () =>
+      invokeEdgeWithFallback<any>('google-nlp', { text }, () => mockAnalyzeSentiment(text))
+  );
+
+  if (data && typeof data === 'object' && (typeof data.score === 'number' || typeof data.sentiment === 'number')) {
+    return {
+      score: data.score ?? data.sentiment ?? 0,
+      magnitude: data.magnitude ?? 0.5,
+      themes: Array.isArray(data.themes) && data.themes.length ? data.themes : COFFEE_SHOP_THEMES.slice(0, 3),
+      summary: data.summary || mockAnalyzeSentiment(text).summary,
+    };
+  }
+  return mockAnalyzeSentiment(text);
 };
 
 // Mock function to analyze sentiment for a venue
@@ -189,18 +209,14 @@ export const analyzeVenueSentiment = async (venueId: string, venueName: string =
   };
 };
 
-// Mock function to analyze sentiment of multiple texts
+// Analyze sentiment of multiple texts (routes each through the edge function
+// with local mock fallback).
 export const analyzeBatchSentiment = async (texts: string[]): Promise<SentimentAnalysisResult[]> => {
   try {
-    return texts.map(text => ({
-      score: Math.random() * 1.5 - 0.25, // Coffee shop bias
-      magnitude: Math.random() * 0.8 + 0.2,
-      themes: COFFEE_SHOP_THEMES.slice(0, 2),
-      summary: `Analysis for coffee shop review: ${text.substring(0, 50)}...`
-    }));
+    return await Promise.all(texts.map((text) => analyzeSentiment(text)));
   } catch (error) {
     console.error('Error in batch sentiment analysis:', error);
-    throw error;
+    return texts.map((text) => mockAnalyzeSentiment(text));
   }
 };
 

--- a/src/services/settings/useSettingsPreferences.ts
+++ b/src/services/settings/useSettingsPreferences.ts
@@ -1,0 +1,77 @@
+/**
+ * Settings persistence helper for Vibe Right Now (Phase 2).
+ *
+ * Wraps `preferencesRepo` so settings pages can hydrate persisted user preferences
+ * and save patches with a single hook. Works signed-out (preferencesRepo persists to
+ * localStorage) and signed-in (Supabase `user_preferences` table). Writes show a sonner
+ * sign-in toast when there is no authenticated user, but still persist locally so the
+ * demo experience survives a refresh.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { preferencesRepo } from "@/services/data";
+import { useUserStore } from "@/store";
+
+export type Preferences = Record<string, unknown>;
+
+export function useSettingsPreferences() {
+  const { user, isAuthenticated } = useUserStore();
+  const userId = user?.id ?? null;
+  const [preferences, setPreferences] = useState<Preferences>({});
+  const [loaded, setLoaded] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Hydrate once per user identity change.
+  useEffect(() => {
+    let active = true;
+    setLoaded(false);
+    preferencesRepo
+      .get(userId)
+      .then((prefs) => {
+        if (active) {
+          setPreferences(prefs ?? {});
+          setLoaded(true);
+        }
+      })
+      .catch((err) => {
+        console.warn("[useSettingsPreferences] get failed", err);
+        if (active) setLoaded(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, [userId]);
+
+  /**
+   * Merge-persist a patch of preferences. Returns the merged blob. Surfaces a sign-in
+   * toast (informational) when signed out, but still persists locally so the demo works.
+   */
+  const save = useCallback(
+    async (patch: Preferences, opts?: { silent?: boolean }) => {
+      setSaving(true);
+      // Optimistic local merge for immediate UI feedback.
+      setPreferences((prev) => ({ ...prev, ...patch }));
+      try {
+        const merged = await preferencesRepo.update(userId, patch);
+        setPreferences(merged);
+        if (!opts?.silent) {
+          if (!isAuthenticated) {
+            toast.info("Saved on this device. Sign in to sync your preferences.");
+          } else {
+            toast.success("Preferences saved");
+          }
+        }
+        return merged;
+      } catch (err) {
+        console.warn("[useSettingsPreferences] update failed", err);
+        if (!opts?.silent) toast.error("Could not save your preferences.");
+        throw err;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [userId, isAuthenticated],
+  );
+
+  return { preferences, loaded, saving, save, isAuthenticated, userId };
+}

--- a/src/services/social/followService.ts
+++ b/src/services/social/followService.ts
@@ -1,0 +1,77 @@
+import { supabase, table } from "@/services/data";
+
+/**
+ * Follow graph helpers built on the `follows` table (follower_id, followee_id).
+ *
+ * Reads are tolerant: when the query errors or the table is empty they return
+ * safe defaults so signed-out / mock mode keeps rendering. Writes require an
+ * authenticated session (RLS enforces follower_id = auth.uid()); callers should
+ * gate them on the current store user and surface a sign-in prompt otherwise.
+ */
+export const followService = {
+  /** Is `followerId` currently following `followeeId`? */
+  async isFollowing(followerId: string, followeeId: string): Promise<boolean> {
+    if (!followerId || !followeeId) return false;
+    try {
+      const { data, error } = await table("follows")
+        .select("follower_id")
+        .eq("follower_id", followerId)
+        .eq("followee_id", followeeId)
+        .maybeSingle();
+      if (error) throw error;
+      return !!data;
+    } catch (err) {
+      console.warn("[follows.isFollowing] fallback:", err);
+      return false;
+    }
+  },
+
+  /** Follow a user. Idempotent: duplicate rows are ignored. */
+  async follow(followerId: string, followeeId: string): Promise<void> {
+    const { error } = await table("follows").insert({
+      follower_id: followerId,
+      followee_id: followeeId,
+    });
+    if (error && (error as { code?: string }).code !== "23505") throw error;
+  },
+
+  /** Unfollow a user. */
+  async unfollow(followerId: string, followeeId: string): Promise<void> {
+    const { error } = await table("follows")
+      .delete()
+      .eq("follower_id", followerId)
+      .eq("followee_id", followeeId);
+    if (error) throw error;
+  },
+
+  /** Number of followers for a user. */
+  async followerCount(userId: string): Promise<number> {
+    try {
+      const { count, error } = await table("follows")
+        .select("follower_id", { count: "exact", head: true })
+        .eq("followee_id", userId);
+      if (error) throw error;
+      return count ?? 0;
+    } catch (err) {
+      console.warn("[follows.followerCount] fallback:", err);
+      return 0;
+    }
+  },
+
+  /** Number of accounts a user follows. */
+  async followingCount(userId: string): Promise<number> {
+    try {
+      const { count, error } = await table("follows")
+        .select("followee_id", { count: "exact", head: true })
+        .eq("follower_id", userId);
+      if (error) throw error;
+      return count ?? 0;
+    } catch (err) {
+      console.warn("[follows.followingCount] fallback:", err);
+      return 0;
+    }
+  },
+};
+
+export { supabase };
+export default followService;

--- a/src/services/social/pointsService.ts
+++ b/src/services/social/pointsService.ts
@@ -1,0 +1,63 @@
+import { table, withFallback } from "@/services/data";
+
+export interface PointsLedgerEntry {
+  id: string;
+  points: number;
+  reason: string;
+  createdAt: string;
+}
+
+/** Demo fallback ledger shown when signed out or the ledger is empty. */
+const mockLedger: PointsLedgerEntry[] = [
+  { id: "m1", points: 25, reason: "Checked in at Griffith Observatory", createdAt: "2025-04-04T12:00:00Z" },
+  { id: "m2", points: 75, reason: "Posted a video at Crypto.com Arena", createdAt: "2025-04-02T12:00:00Z" },
+  { id: "m3", points: 50, reason: "5-day streak bonus", createdAt: "2025-04-01T12:00:00Z" },
+  { id: "m4", points: 30, reason: "Verified Venice Beach review", createdAt: "2025-03-28T12:00:00Z" },
+  { id: "m5", points: 45, reason: "Shared 3 locations", createdAt: "2025-03-25T12:00:00Z" },
+];
+
+const MOCK_TOTAL = 1250;
+
+export const pointsService = {
+  /** Total points for a user (profiles.points), falling back to a demo total. */
+  async getTotal(userId?: string): Promise<number> {
+    if (!userId) return MOCK_TOTAL;
+    return withFallback<number>(
+      "points.getTotal",
+      async () => {
+        const { data, error } = await table("profiles")
+          .select("points")
+          .eq("id", userId)
+          .maybeSingle();
+        return { data: data ? (data.points as number) : null, error };
+      },
+      () => MOCK_TOTAL,
+      false,
+    );
+  },
+
+  /** Recent points ledger entries for a user, falling back to demo activity. */
+  async getLedger(userId?: string, limit = 20): Promise<PointsLedgerEntry[]> {
+    if (!userId) return mockLedger;
+    return withFallback<PointsLedgerEntry[]>(
+      "points.getLedger",
+      async () => {
+        const { data, error } = await table("points_ledger")
+          .select("*")
+          .eq("user_id", userId)
+          .order("created_at", { ascending: false })
+          .limit(limit);
+        const rows = (data ?? []).map((r: any) => ({
+          id: r.id,
+          points: r.points,
+          reason: r.reason ?? "Points activity",
+          createdAt: r.created_at,
+        }));
+        return { data: rows, error };
+      },
+      () => mockLedger,
+    );
+  },
+};
+
+export default pointsService;

--- a/src/services/trips/tripCollabService.ts
+++ b/src/services/trips/tripCollabService.ts
@@ -1,0 +1,297 @@
+/**
+ * Trip collaboration + "My Places" persistence helpers (Stream E).
+ *
+ * These wrap the Supabase tables that don't have a first-class repo in
+ * `@/services/data` yet (trip_members, trip_venue_ideas, trip_venue_votes,
+ * trip_messages, user_places). They use the untyped `table()` accessor and the
+ * `withFallback` semantics from the data layer so the UI keeps rendering from
+ * mock/local data when the DB is empty, unreachable, or the user is signed out.
+ *
+ * Writes require a session. `getCurrentUserId()` resolves the signed-in user id
+ * (Supabase auth first, then the Zustand store as a fallback for the demo). When
+ * no session exists, callers should surface a sign-in prompt instead of writing.
+ */
+import { supabase, table, USE_MOCK_FALLBACK } from "@/services/data";
+
+export interface TripCollaborator {
+  id: string;
+  name: string;
+  avatar: string;
+}
+
+export interface VenueVote {
+  id: string;
+  vote_type: "up" | "down";
+  user_name: string;
+  user_avatar: string;
+}
+
+export interface VenueIdeaRecord {
+  id: string;
+  venue_id: string;
+  venue_name: string;
+  venue_address: string | null;
+  venue_city: string | null;
+  venue_rating: number | null;
+  venue_image_url: string | null;
+  proposed_by_id: string;
+  proposed_by_name: string;
+  proposed_by_avatar: string;
+  notes: string | null;
+  status: string;
+  created_at: string;
+  trip_id: string;
+  trip_venue_votes?: VenueVote[];
+}
+
+export interface TripMessageRecord {
+  id: string;
+  trip_id: string;
+  content: string;
+  user_id: string;
+  user_name: string;
+  user_avatar: string;
+  message_type: string;
+  created_at: string;
+}
+
+/**
+ * Resolve the current signed-in user id. Returns null when signed out so callers
+ * can show a sign-in prompt rather than throwing on a write.
+ */
+export async function getCurrentUserId(): Promise<string | null> {
+  try {
+    const { data } = await supabase.auth.getUser();
+    if (data?.user?.id) return data.user.id;
+  } catch (err) {
+    console.warn("[tripCollab] auth.getUser failed:", err);
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// trip_members
+// ---------------------------------------------------------------------------
+
+export async function listTripMembers(tripId: string): Promise<TripCollaborator[]> {
+  try {
+    const { data, error } = await table("trip_members")
+      .select("user_id, role")
+      .eq("trip_id", tripId);
+    if (error) throw error;
+    const rows = (data ?? []) as Array<{ user_id: string; role: string }>;
+    if (rows.length === 0) return [];
+
+    // Resolve profiles in a second query (avoids relying on a named FK embed for
+    // a table that isn't in the generated Supabase types yet).
+    const userIds = rows.map((r) => r.user_id);
+    const { data: profiles } = await table("profiles")
+      .select("id, username, display_name, avatar_url")
+      .in("id", userIds);
+    const profileById = new Map(
+      ((profiles ?? []) as any[]).map((p) => [p.id, p]),
+    );
+
+    return rows.map((row) => {
+      const profile = profileById.get(row.user_id) ?? {};
+      return {
+        id: row.user_id,
+        name: profile.display_name || profile.username || "Traveler",
+        avatar: profile.avatar_url || "/placeholder.svg",
+      } as TripCollaborator;
+    });
+  } catch (err) {
+    if (USE_MOCK_FALLBACK) {
+      console.warn("[tripCollab] listTripMembers fallback:", err);
+      return [];
+    }
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// trip_venue_ideas / trip_venue_votes
+// ---------------------------------------------------------------------------
+
+export async function listVenueIdeas(tripId: string): Promise<VenueIdeaRecord[]> {
+  try {
+    const { data, error } = await table("trip_venue_ideas")
+      .select(
+        `*, trip_venue_votes ( id, vote_type, user_name, user_avatar )`,
+      )
+      .eq("trip_id", tripId)
+      .order("created_at", { ascending: false });
+    if (error) throw error;
+    return (data ?? []) as VenueIdeaRecord[];
+  } catch (err) {
+    if (USE_MOCK_FALLBACK) {
+      console.warn("[tripCollab] listVenueIdeas fallback:", err);
+      return [];
+    }
+    throw err;
+  }
+}
+
+export async function proposeVenueIdea(idea: {
+  trip_id: string;
+  venue_id: string;
+  venue_name: string;
+  venue_address?: string | null;
+  venue_city?: string | null;
+  venue_rating?: number | null;
+  venue_image_url?: string | null;
+  proposed_by_id: string;
+  proposed_by_name: string;
+  proposed_by_avatar: string;
+  notes?: string | null;
+  status?: string;
+}): Promise<VenueIdeaRecord> {
+  const { data, error } = await table("trip_venue_ideas")
+    .insert({
+      trip_id: idea.trip_id,
+      venue_id: idea.venue_id,
+      venue_name: idea.venue_name,
+      venue_address: idea.venue_address ?? null,
+      venue_city: idea.venue_city ?? null,
+      venue_rating: idea.venue_rating ?? null,
+      venue_image_url: idea.venue_image_url ?? null,
+      proposed_by_id: idea.proposed_by_id,
+      proposed_by_name: idea.proposed_by_name,
+      proposed_by_avatar: idea.proposed_by_avatar,
+      notes: idea.notes ?? null,
+      status: idea.status ?? "pending",
+    })
+    .select("*")
+    .single();
+  if (error) throw error;
+  return data as VenueIdeaRecord;
+}
+
+export async function voteOnVenueIdea(vote: {
+  venue_idea_id: string;
+  vote_type: "up" | "down";
+  user_id: string;
+  user_name: string;
+  user_avatar: string;
+}): Promise<void> {
+  const { error } = await table("trip_venue_votes").insert({
+    venue_idea_id: vote.venue_idea_id,
+    vote_type: vote.vote_type,
+    user_id: vote.user_id,
+    user_name: vote.user_name,
+    user_avatar: vote.user_avatar,
+  });
+  if (error) throw error;
+}
+
+// ---------------------------------------------------------------------------
+// trip_messages
+// ---------------------------------------------------------------------------
+
+export async function listTripMessages(tripId: string): Promise<TripMessageRecord[]> {
+  try {
+    const { data, error } = await table("trip_messages")
+      .select("*")
+      .eq("trip_id", tripId)
+      .order("created_at", { ascending: true });
+    if (error) throw error;
+    return (data ?? []) as TripMessageRecord[];
+  } catch (err) {
+    if (USE_MOCK_FALLBACK) {
+      console.warn("[tripCollab] listTripMessages fallback:", err);
+      return [];
+    }
+    throw err;
+  }
+}
+
+export async function sendTripMessage(message: {
+  trip_id: string;
+  content: string;
+  user_id: string;
+  user_name: string;
+  user_avatar: string;
+  message_type?: string;
+}): Promise<TripMessageRecord> {
+  const { data, error } = await table("trip_messages")
+    .insert({
+      trip_id: message.trip_id,
+      content: message.content,
+      user_id: message.user_id,
+      user_name: message.user_name,
+      user_avatar: message.user_avatar,
+      message_type: message.message_type ?? "text",
+    })
+    .select("*")
+    .single();
+  if (error) throw error;
+  return data as TripMessageRecord;
+}
+
+// ---------------------------------------------------------------------------
+// user_places (My Places)
+// ---------------------------------------------------------------------------
+
+export type UserPlaceStatus = "visited" | "want_to_visit";
+
+export interface UserPlaceRecord {
+  id: string;
+  user_id: string;
+  location_id: string;
+  location_name: string | null;
+  location_city: string | null;
+  status: UserPlaceStatus;
+  created_at: string;
+}
+
+export async function listUserPlaces(
+  userId: string,
+  status: UserPlaceStatus,
+): Promise<UserPlaceRecord[]> {
+  try {
+    const { data, error } = await table("user_places")
+      .select("*")
+      .eq("user_id", userId)
+      .eq("status", status)
+      .order("created_at", { ascending: false });
+    if (error) throw error;
+    return (data ?? []) as UserPlaceRecord[];
+  } catch (err) {
+    if (USE_MOCK_FALLBACK) {
+      console.warn("[tripCollab] listUserPlaces fallback:", err);
+      return [];
+    }
+    throw err;
+  }
+}
+
+export async function addUserPlace(place: {
+  user_id: string;
+  location_id: string;
+  location_name?: string | null;
+  location_city?: string | null;
+  status: UserPlaceStatus;
+}): Promise<void> {
+  const { error } = await table("user_places").insert({
+    user_id: place.user_id,
+    location_id: place.location_id,
+    location_name: place.location_name ?? null,
+    location_city: place.location_city ?? null,
+    status: place.status,
+  });
+  // 23505 = unique violation (already saved with this status) — treat as success.
+  if (error && (error as any).code !== "23505") throw error;
+}
+
+export async function removeUserPlace(
+  userId: string,
+  locationId: string,
+  status: UserPlaceStatus,
+): Promise<void> {
+  const { error } = await table("user_places")
+    .delete()
+    .eq("user_id", userId)
+    .eq("location_id", locationId)
+    .eq("status", status);
+  if (error) throw error;
+}

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -2,6 +2,24 @@
 import { StateCreator } from 'zustand';
 import { AppStore, UserSlice, User } from './types';
 import { useAppStore } from './appStore';
+import type { User as RichUser } from '@/types';
+
+/**
+ * Map the rich profile `User` (returned by profilesRepo / Supabase auth) into the
+ * lightweight Zustand store `User` shape. Centralized here so the Supabase auth
+ * provider has a single source of truth for the mapping.
+ */
+export function mapProfileToStoreUser(profile: RichUser, fallbackEmail?: string): User {
+  const tier = (profile.subscription as unknown as string) ?? 'free';
+  return {
+    id: profile.id,
+    name: profile.displayName || profile.name || profile.username || '',
+    email: profile.email ?? fallbackEmail ?? '',
+    avatar: profile.avatar,
+    subscription: (tier === 'pro' || tier === 'premium' ? tier : 'free') as User['subscription'],
+    points: profile.points ?? 0,
+  };
+}
 
 export const createUserSlice: StateCreator<
   AppStore,

--- a/src/utils/venue/postManagementUtils.ts
+++ b/src/utils/venue/postManagementUtils.ts
@@ -1,6 +1,8 @@
 
 import { Post } from "@/types";
 import { toast } from "sonner";
+import { postsRepo } from "@/services/data";
+import { getCurrentUserId } from "@/services/posts/currentUser";
 
 // Check if a user has the necessary subscription to delete posts
 export const canDeleteUserPosts = (subscriptionTier: string): boolean => {
@@ -8,13 +10,45 @@ export const canDeleteUserPosts = (subscriptionTier: string): boolean => {
   return paidTiers.includes(subscriptionTier);
 };
 
-// Handle post deletion (mock implementation)
+/**
+ * Determine whether the current user is allowed to delete a post.
+ * Only the post's author may delete it.
+ */
+export const canCurrentUserDeletePost = (post: Post, currentUserId: string | null): boolean => {
+  if (!currentUserId) return false;
+  return post.userId === currentUserId || post.user?.id === currentUserId;
+};
+
+/**
+ * Delete a post via the data layer. Only succeeds when a user is signed in and is the
+ * author of the post. Returns true when the post was removed.
+ */
+export const deletePostById = async (post: Post): Promise<boolean> => {
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    toast("Sign in to manage your posts");
+    return false;
+  }
+  if (!canCurrentUserDeletePost(post, userId)) {
+    toast.error("You can only delete your own posts.");
+    return false;
+  }
+
+  try {
+    await postsRepo.remove(post.id);
+    toast.success("Post deleted");
+    return true;
+  } catch (error) {
+    console.error("Error deleting post:", error);
+    toast.error("Failed to delete post. Please try again.");
+    return false;
+  }
+};
+
+// Legacy venue-context delete helper (kept for backwards compatibility with venue grids).
 export const deletePost = (postId: string, venue: { id: string; name: string }): boolean => {
   try {
-    // In a real app, this would call an API endpoint to delete the post
     console.log(`Deleting post ${postId} from venue ${venue.id}`);
-    
-    // For demo purposes, this just shows a success toast
     toast.success(`Post removed from ${venue.name}`);
     return true;
   } catch (error) {
@@ -29,6 +63,6 @@ export const createVenuePost = (venueId: string, content: string, media: File[])
   // In a real app, this would upload media and create a post with the venue location
   console.log(`Creating post at venue ${venueId} with content: ${content}`);
   console.log(`Media files:`, media);
-  
+
   toast.success("Your post was added successfully!");
 };

--- a/supabase/migrations/20260601120000_core_social_schema.sql
+++ b/supabase/migrations/20260601120000_core_social_schema.sql
@@ -1,0 +1,319 @@
+-- Core social schema for Vibe Right Now
+-- Adds the user/post/social tables the front-end expects (none existed before).
+-- Reuses the existing public.update_updated_at_column() trigger function created in
+-- the venue_audio_summaries migration. Apply on the owning Supabase account via
+-- `supabase db push` or the dashboard SQL editor, then regenerate
+-- src/integrations/supabase/types.ts.
+
+-- ---------------------------------------------------------------------------
+-- profiles (1:1 with auth.users)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.profiles (
+  id UUID NOT NULL PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  username TEXT UNIQUE,
+  display_name TEXT,
+  name TEXT,
+  email TEXT,
+  avatar_url TEXT,
+  bio TEXT,
+  verified BOOLEAN NOT NULL DEFAULT false,
+  is_private BOOLEAN NOT NULL DEFAULT false,
+  points INTEGER NOT NULL DEFAULT 0,
+  subscription_tier TEXT NOT NULL DEFAULT 'free',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Auto-create a profile row whenever a new auth user signs up.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.profiles (id, email, username, name, display_name, avatar_url)
+  VALUES (
+    NEW.id,
+    NEW.email,
+    COALESCE(NEW.raw_user_meta_data->>'username', split_part(NEW.email, '@', 1)),
+    COALESCE(NEW.raw_user_meta_data->>'name', split_part(NEW.email, '@', 1)),
+    COALESCE(NEW.raw_user_meta_data->>'name', split_part(NEW.email, '@', 1)),
+    NEW.raw_user_meta_data->>'avatar_url'
+  )
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- ---------------------------------------------------------------------------
+-- posts
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.posts (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  author_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  -- location_id is kept as TEXT (no FK) so it can reference either the public.locations
+  -- table or external Google/Yelp place ids without friction.
+  location_id TEXT,
+  location_name TEXT,
+  location_city TEXT,
+  location_state TEXT,
+  content TEXT NOT NULL DEFAULT '',
+  media JSONB NOT NULL DEFAULT '[]'::jsonb,
+  vibe_tags TEXT[] NOT NULL DEFAULT '{}',
+  visibility TEXT NOT NULL DEFAULT 'public',
+  is_venue_post BOOLEAN NOT NULL DEFAULT false,
+  likes_count INTEGER NOT NULL DEFAULT 0,
+  comments_count INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_posts_author ON public.posts(author_id);
+CREATE INDEX IF NOT EXISTS idx_posts_location ON public.posts(location_id);
+CREATE INDEX IF NOT EXISTS idx_posts_created ON public.posts(created_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- comments
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.comments (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  post_id UUID NOT NULL REFERENCES public.posts(id) ON DELETE CASCADE,
+  author_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  parent_id UUID REFERENCES public.comments(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  likes_count INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_comments_post ON public.comments(post_id);
+
+-- ---------------------------------------------------------------------------
+-- engagement: likes, saves, follows
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.post_likes (
+  post_id UUID NOT NULL REFERENCES public.posts(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (post_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.saved_posts (
+  post_id UUID NOT NULL REFERENCES public.posts(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (post_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.follows (
+  follower_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  followee_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (follower_id, followee_id),
+  CHECK (follower_id <> followee_id)
+);
+
+-- ---------------------------------------------------------------------------
+-- check-ins + my places (visited / want-to-visit)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.check_ins (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  location_id TEXT,
+  location_name TEXT,
+  photo_url TEXT,
+  note TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_check_ins_user ON public.check_ins(user_id);
+
+CREATE TABLE IF NOT EXISTS public.user_places (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  location_id TEXT NOT NULL,
+  location_name TEXT,
+  location_city TEXT,
+  status TEXT NOT NULL DEFAULT 'want_to_visit', -- 'visited' | 'want_to_visit'
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, location_id, status)
+);
+CREATE INDEX IF NOT EXISTS idx_user_places_user ON public.user_places(user_id);
+
+-- ---------------------------------------------------------------------------
+-- trips (parent table; trip_messages / trip_venue_ideas already reference trip_id)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.trips (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  owner_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  description TEXT,
+  start_date DATE,
+  end_date DATE,
+  cover_image_url TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.trip_members (
+  trip_id UUID NOT NULL REFERENCES public.trips(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'member', -- 'owner' | 'member'
+  joined_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (trip_id, user_id)
+);
+
+-- ---------------------------------------------------------------------------
+-- points ledger (gamification)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.points_ledger (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  points INTEGER NOT NULL,
+  reason TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_points_ledger_user ON public.points_ledger(user_id);
+
+-- ---------------------------------------------------------------------------
+-- denormalized counter triggers
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.bump_post_likes_count()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE public.posts SET likes_count = likes_count + 1 WHERE id = NEW.post_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE public.posts SET likes_count = GREATEST(likes_count - 1, 0) WHERE id = OLD.post_id;
+  END IF;
+  RETURN NULL;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_post_likes_count ON public.post_likes;
+CREATE TRIGGER trg_post_likes_count
+  AFTER INSERT OR DELETE ON public.post_likes
+  FOR EACH ROW EXECUTE FUNCTION public.bump_post_likes_count();
+
+CREATE OR REPLACE FUNCTION public.bump_post_comments_count()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE public.posts SET comments_count = comments_count + 1 WHERE id = NEW.post_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE public.posts SET comments_count = GREATEST(comments_count - 1, 0) WHERE id = OLD.post_id;
+  END IF;
+  RETURN NULL;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_post_comments_count ON public.comments;
+CREATE TRIGGER trg_post_comments_count
+  AFTER INSERT OR DELETE ON public.comments
+  FOR EACH ROW EXECUTE FUNCTION public.bump_post_comments_count();
+
+-- updated_at triggers (reuse existing public.update_updated_at_column)
+CREATE TRIGGER trg_profiles_updated_at BEFORE UPDATE ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+CREATE TRIGGER trg_posts_updated_at BEFORE UPDATE ON public.posts
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+CREATE TRIGGER trg_comments_updated_at BEFORE UPDATE ON public.comments
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+CREATE TRIGGER trg_trips_updated_at BEFORE UPDATE ON public.trips
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+-- ---------------------------------------------------------------------------
+-- Row Level Security
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.profiles      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.posts         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.comments      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.post_likes    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.saved_posts   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.follows       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.check_ins     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_places   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.trips         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.trip_members  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.points_ledger ENABLE ROW LEVEL SECURITY;
+
+-- profiles: world-readable, self-writable
+CREATE POLICY "profiles_select_all" ON public.profiles FOR SELECT USING (true);
+CREATE POLICY "profiles_insert_self" ON public.profiles FOR INSERT WITH CHECK (auth.uid() = id);
+CREATE POLICY "profiles_update_self" ON public.profiles FOR UPDATE USING (auth.uid() = id);
+
+-- posts: public ones readable by anyone, private/friends only by author; author writes own
+CREATE POLICY "posts_select_visible" ON public.posts FOR SELECT
+  USING (visibility = 'public' OR author_id = auth.uid());
+CREATE POLICY "posts_insert_own" ON public.posts FOR INSERT WITH CHECK (author_id = auth.uid());
+CREATE POLICY "posts_update_own" ON public.posts FOR UPDATE USING (author_id = auth.uid());
+CREATE POLICY "posts_delete_own" ON public.posts FOR DELETE USING (author_id = auth.uid());
+
+-- comments: readable by all, author writes own
+CREATE POLICY "comments_select_all" ON public.comments FOR SELECT USING (true);
+CREATE POLICY "comments_insert_own" ON public.comments FOR INSERT WITH CHECK (author_id = auth.uid());
+CREATE POLICY "comments_update_own" ON public.comments FOR UPDATE USING (author_id = auth.uid());
+CREATE POLICY "comments_delete_own" ON public.comments FOR DELETE USING (author_id = auth.uid());
+
+-- likes / saves / follows: readable by all, user manages own rows
+CREATE POLICY "post_likes_select_all" ON public.post_likes FOR SELECT USING (true);
+CREATE POLICY "post_likes_write_own" ON public.post_likes FOR ALL
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "saved_posts_select_own" ON public.saved_posts FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "saved_posts_write_own" ON public.saved_posts FOR ALL
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "follows_select_all" ON public.follows FOR SELECT USING (true);
+CREATE POLICY "follows_write_own" ON public.follows FOR ALL
+  USING (follower_id = auth.uid()) WITH CHECK (follower_id = auth.uid());
+
+-- check-ins / user_places: readable by all, owner writes own
+CREATE POLICY "check_ins_select_all" ON public.check_ins FOR SELECT USING (true);
+CREATE POLICY "check_ins_write_own" ON public.check_ins FOR ALL
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "user_places_select_own" ON public.user_places FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "user_places_write_own" ON public.user_places FOR ALL
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+-- trips: visible to owner + members; owner writes
+CREATE POLICY "trips_select_member" ON public.trips FOR SELECT
+  USING (owner_id = auth.uid() OR EXISTS (
+    SELECT 1 FROM public.trip_members m WHERE m.trip_id = id AND m.user_id = auth.uid()
+  ));
+CREATE POLICY "trips_insert_own" ON public.trips FOR INSERT WITH CHECK (owner_id = auth.uid());
+CREATE POLICY "trips_update_own" ON public.trips FOR UPDATE USING (owner_id = auth.uid());
+CREATE POLICY "trips_delete_own" ON public.trips FOR DELETE USING (owner_id = auth.uid());
+
+CREATE POLICY "trip_members_select_member" ON public.trip_members FOR SELECT
+  USING (user_id = auth.uid() OR EXISTS (
+    SELECT 1 FROM public.trips t WHERE t.id = trip_id AND t.owner_id = auth.uid()
+  ));
+CREATE POLICY "trip_members_write_owner" ON public.trip_members FOR ALL
+  USING (EXISTS (SELECT 1 FROM public.trips t WHERE t.id = trip_id AND t.owner_id = auth.uid()))
+  WITH CHECK (EXISTS (SELECT 1 FROM public.trips t WHERE t.id = trip_id AND t.owner_id = auth.uid()));
+
+-- points ledger: owner reads own
+CREATE POLICY "points_ledger_select_own" ON public.points_ledger FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "points_ledger_insert_own" ON public.points_ledger FOR INSERT WITH CHECK (user_id = auth.uid());
+
+-- ---------------------------------------------------------------------------
+-- Storage buckets for media
+-- ---------------------------------------------------------------------------
+INSERT INTO storage.buckets (id, name, public)
+  VALUES ('avatars', 'avatars', true)
+  ON CONFLICT (id) DO NOTHING;
+INSERT INTO storage.buckets (id, name, public)
+  VALUES ('post-media', 'post-media', true)
+  ON CONFLICT (id) DO NOTHING;
+
+CREATE POLICY "avatars_public_read" ON storage.objects FOR SELECT
+  USING (bucket_id = 'avatars');
+CREATE POLICY "avatars_auth_write" ON storage.objects FOR INSERT
+  WITH CHECK (bucket_id = 'avatars' AND auth.role() = 'authenticated');
+CREATE POLICY "post_media_public_read" ON storage.objects FOR SELECT
+  USING (bucket_id = 'post-media');
+CREATE POLICY "post_media_auth_write" ON storage.objects FOR INSERT
+  WITH CHECK (bucket_id = 'post-media' AND auth.role() = 'authenticated');

--- a/supabase/migrations/20260601130000_messaging_notifications_prefs.sql
+++ b/supabase/migrations/20260601130000_messaging_notifications_prefs.sql
@@ -1,0 +1,105 @@
+-- Phase 2 schema: messaging, notifications, and user preferences.
+-- Builds on 20260601120000_core_social_schema (profiles, etc.). Apply on the owning
+-- Supabase account and regenerate src/integrations/supabase/types.ts afterwards.
+
+-- ---------------------------------------------------------------------------
+-- conversations + messages (user <-> venue and user <-> user DMs)
+-- A conversation is keyed by a free-text thread key (e.g. a venue id) so it can
+-- represent both venue messaging and direct messages without a rigid participant model.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.conversations (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  thread_key TEXT NOT NULL,                 -- e.g. venue id, or "dm:<uid>:<uid>"
+  title TEXT,
+  venue_id TEXT,                            -- set for venue conversations
+  venue_name TEXT,
+  venue_avatar TEXT,
+  created_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (thread_key, created_by)
+);
+CREATE INDEX IF NOT EXISTS idx_conversations_thread ON public.conversations(thread_key);
+
+CREATE TABLE IF NOT EXISTS public.messages (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  conversation_id UUID NOT NULL REFERENCES public.conversations(id) ON DELETE CASCADE,
+  sender_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  sender_type TEXT NOT NULL DEFAULT 'user',  -- 'user' | 'venue'
+  message_type TEXT NOT NULL DEFAULT 'general',
+  content TEXT NOT NULL,
+  read BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_messages_conversation ON public.messages(conversation_id, created_at);
+
+-- ---------------------------------------------------------------------------
+-- notifications
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.notifications (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  type TEXT NOT NULL DEFAULT 'info',
+  title TEXT NOT NULL,
+  body TEXT,
+  link TEXT,
+  read BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_notifications_user ON public.notifications(user_id, read);
+
+-- ---------------------------------------------------------------------------
+-- user_preferences (settings tabs: content, privacy, transportation, etc.)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.user_preferences (
+  user_id UUID NOT NULL PRIMARY KEY REFERENCES public.profiles(id) ON DELETE CASCADE,
+  preferences JSONB NOT NULL DEFAULT '{}'::jsonb,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- updated_at triggers (reuse existing public.update_updated_at_column)
+CREATE TRIGGER trg_conversations_updated_at BEFORE UPDATE ON public.conversations
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+CREATE TRIGGER trg_user_preferences_updated_at BEFORE UPDATE ON public.user_preferences
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+-- ---------------------------------------------------------------------------
+-- RLS
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.conversations    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.messages         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.notifications    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_preferences ENABLE ROW LEVEL SECURITY;
+
+-- conversations: a user sees/creates their own conversation threads
+CREATE POLICY "conversations_select_own" ON public.conversations FOR SELECT
+  USING (created_by = auth.uid());
+CREATE POLICY "conversations_write_own" ON public.conversations FOR ALL
+  USING (created_by = auth.uid()) WITH CHECK (created_by = auth.uid());
+
+-- messages: readable/writable by the owner of the parent conversation
+CREATE POLICY "messages_select_participant" ON public.messages FOR SELECT
+  USING (EXISTS (
+    SELECT 1 FROM public.conversations c
+    WHERE c.id = conversation_id AND c.created_by = auth.uid()
+  ));
+CREATE POLICY "messages_insert_participant" ON public.messages FOR INSERT
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.conversations c
+    WHERE c.id = conversation_id AND c.created_by = auth.uid()
+  ));
+CREATE POLICY "messages_update_participant" ON public.messages FOR UPDATE
+  USING (EXISTS (
+    SELECT 1 FROM public.conversations c
+    WHERE c.id = conversation_id AND c.created_by = auth.uid()
+  ));
+
+-- notifications: owner only
+CREATE POLICY "notifications_select_own" ON public.notifications FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "notifications_write_own" ON public.notifications FOR ALL
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+-- user_preferences: owner only
+CREATE POLICY "user_preferences_select_own" ON public.user_preferences FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "user_preferences_write_own" ON public.user_preferences FOR ALL
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive data-access layer backed by Supabase with transparent mock-data fallback, Supabase authentication, and trip collaboration features. The app now persists user profiles, posts, comments, messages, notifications, and preferences to the database while gracefully degrading to demo content when offline or unauthenticated.

## Key Changes

### Data Layer & Repositories
- **New `src/services/data/` layer** with typed repositories for posts, profiles, comments, locations, messages, notifications, preferences, and trips
- **Mock fallback pattern**: All reads transparently fall back to `src/mock/*` data when the database is empty, unreachable, or the user is signed out (controlled by `VITE_USE_MOCK_FALLBACK`)
- **Edge function wrapper** (`src/services/edge/invokeEdge.ts`) for consistent error handling and fallback routing across AI/search integrations (Vertex AI, OpenAI, Perplexity, Google NLP, etc.)

### Authentication & User Management
- **Supabase Auth Provider** (`src/auth/SupabaseAuthProvider.tsx`) managing session state and auth actions (sign-in, sign-up, magic link, Google OAuth, sign-out)
- **User store integration** mapping Supabase profiles to the app's User type
- **Session-aware writes**: Post creation, follows, check-ins, and trip collaboration require authentication; callers show sign-in prompts when unsigned out

### Trip Collaboration (Stream E)
- **Trip collaboration service** (`src/services/trips/tripCollabService.ts`) wrapping trip members, venue ideas, votes, and messages
- **Trip chat & ideas UI** updated to use the new service instead of the old database layer
- **Supabase migrations** (`20260601120000_core_social_schema.sql`, `20260601130000_messaging_notifications_prefs.sql`) creating profiles, posts, conversations, messages, notifications, and preferences tables with RLS policies

### UI & Component Updates
- **Post creation** (`CreatePostDialog`, `CameraButton`, `CheckInDialog`) now routes through `createPost` service with sign-in fallback
- **Notifications dropdown** uses `notificationsRepo` with demo fallback notifications
- **User profile pages** load posts and follow state through the data layer
- **Trip details, chat, and ideas** integrated with trip collaboration service
- **Settings pages** (account, privacy, preferences) persist to `preferencesRepo`
- **Messaging** (`VenueMessaging`) uses `messagesRepo` for venue conversations

### Service Refactoring
- **AI/LLM services** (OpenAI, Vertex AI, Perplexity, HuggingFace, HuggingChat) now route through `invokeEdgeWithFallback` for consistent error handling and local fallback responses
- **Sentiment analysis** and **content safety** delegated to edge functions
- **Venue recommendations** helper detects intent and returns real venues from `locationsRepo`

### Environment & Configuration
- **`.env.example`** documenting all optional API keys and the mock-fallback behavior
- **`VITE_USE_MOCK_FALLBACK`** flag (defaults to `true`) to control demo vs. real-data-only mode
- **Updated `.gitignore`** to exclude Claude Code local state

## Notable Implementation Details
- **Graceful degradation**: Every read operation falls back to mock data; writes require authentication and show a sign-in toast when unsigned out
- **Consistent error handling**: Edge function invocations use a single wrapper with retry logic and fallback responses
- **RLS policies**: Supabase migrations include row-level security to enforce user isolation
- **Type safety**: All repositories export typed mappers and interfaces compatible with the app's existing types
- **Demo persistence**: Local/mock trips and preferences survive page refreshes via localStorage when signed out

https://claude.ai/code/session_01WijfFMYFFXzeBWTdpVZx3s